### PR TITLE
Fix double free of responses when responding with error

### DIFF
--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -505,9 +505,6 @@ RequestsRespondWithError(
       LOG_MESSAGE(TRITONSERVER_LOG_ERROR, "fail to create response");
       TRITONSERVER_ErrorDelete(err);
     } else {
-      std::unique_ptr<
-          TRITONBACKEND_Response, decltype(&TRITONBACKEND_ResponseDelete)>
-          response_handle(response, TRITONBACKEND_ResponseDelete);
       LOG_IF_ERROR(
           TRITONBACKEND_ResponseSend(
               response, TRITONSERVER_RESPONSE_COMPLETE_FINAL, response_err),


### PR DESCRIPTION
This seems to be a bug when sending out the responses with error. The `response_handle` unique_ptr incorrectly keeps the ownership of the response object even though           TRITONBACKEND_ResponseSend transfers the ownership to the backend.

### Before

```
I0222 11:41:16.035775 1304 tensorflow.cc:2107] model resnet50v1.5_fp16_savedmodel, instance resnet50v1.5_fp16_savedmodel, executing 1 requests
free(): double free detected in tcache 2
Aborted (core dumped)

```

### After

```
No faults.. and server keeps running...
```