### PR TITLE
Add implementation of ReadBinaryFile

### DIFF
--- a/include/triton/backend/backend_common.h
+++ b/include/triton/backend/backend_common.h
@@ -362,6 +362,13 @@ TRITONSERVER_Error* FileExists(const std::string& path, bool* exists);
 TRITONSERVER_Error* ReadTextFile(
     const std::string& path, std::string* contents);
 
+/// Read a binary file into a uint8_t vector.
+/// \param path The path of the file.
+/// \param contents Returns the contents of the file.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_Error* ReadBinaryFile(
+    const std::string& path, std::vector<uint8_t>& contents);
+
 /// Is a path a directory?
 /// \param path The path to check.
 /// \param is_dir Returns true if path represents a directory

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -674,6 +674,23 @@ ReadTextFile(const std::string& path, std::string* contents)
 }
 
 TRITONSERVER_Error*
+ReadBinaryFile(const std::string& path, std::vector<uint8_t>& contents)
+{
+  std::ifstream in(path, std::ios::in | std::ios::binary);
+  if (!in) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INTERNAL,
+        ("failed to open binary file for read " + path + ": " + strerror(errno)).c_str();
+  }
+
+  contents.assign(
+      (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  in.close();
+
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error*
 IsDirectory(const std::string& path, bool* is_dir)
 {
   *is_dir = false;


### PR DESCRIPTION
For the ArmNN backend, reading a serialized model can currently only be done by reading the contents of a binary stream (see [here](https://github.com/ARM-software/armnn/blob/8d229256a4b7a0264fc146abe957c4e0c7887799/include/armnnDeserializer/IDeserializer.hpp#L35). To accommodate this, it may be useful to add this helper function for others to use.