### PR TITLE
Fix No GPU build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,13 @@ add_library(
   src/backend_model_instance.cc
   src/backend_model.cc
   src/backend_output_responder.cc
-  src/kernel.h
 )
+if(${TRITON_ENABLE_GPU})
+  add_library(
+    triton-backend-utils
+    src/kernel.h
+  )
+endif() # TRITON_ENABLE_GPU
 
 if(${TRITON_ENABLE_GPU})
   set(HOST_COMPILER_FLAGS "")
@@ -98,7 +103,7 @@ if(${TRITON_ENABLE_GPU})
 
   set(CUDA_LIBRARIES PUBLIC ${CUDA_LIBRARIES})
   cuda_add_library(
-    kernel-library-new 
+    kernel-library-new
     src/kernel.cu src/kernel.h
     OPTIONS -arch compute_53
     OPTIONS -code compute_53,sm_53,sm_60,sm_61,sm_62,sm_70,sm_72,sm_75
@@ -184,12 +189,22 @@ set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/TritonBackend)
 install(
   TARGETS
     triton-backend-utils
-    kernel-library-new
   EXPORT
     triton-backend-targets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
+if(${TRITON_ENABLE_GPU})
+  install(
+    TARGETS
+      kernel-library-new
+    EXPORT
+      triton-backend-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+endif() # TRITON_ENABLE_GPU
 
 install(
   DIRECTORY include/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ add_library(
   src/backend_model.cc
   src/backend_output_responder.cc
 )
+
 if(${TRITON_ENABLE_GPU})
   add_library(
     triton-backend-utils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,22 +79,23 @@ endif() # TRITON_ENABLE_GPU
 #
 # Backend library containing useful source and utilities
 #
-add_library(
-  triton-backend-utils
-  src/backend_common.cc
-  src/backend_input_collector.cc
-  src/backend_memory.cc
-  src/backend_model_instance.cc
-  src/backend_model.cc
-  src/backend_output_responder.cc
+set(SRC_FILES 
+  "src/backend_common.cc"
+  "src/backend_input_collector.cc"
+  "src/backend_memory.cc"
+  "src/backend_model_instance.cc"
+  "src/backend_model.cc"
+  "src/backend_output_responder.cc"
 )
 
 if(${TRITON_ENABLE_GPU})
-  add_library(
-    triton-backend-utils
-    src/kernel.h
-  )
+  set(SRC_FILES ${SRC_FILES} "src/kernel.h")
 endif() # TRITON_ENABLE_GPU
+
+add_library(
+  triton-backend-utils
+  ${SRC_FILES}
+)
 
 if(${TRITON_ENABLE_GPU})
   set(HOST_COMPILER_FLAGS "")

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -27,8 +27,10 @@
 #include "triton/backend/backend_input_collector.h"
 
 #include <atomic>
-#include "kernel.h"
 #include "triton/backend/backend_common.h"
+#ifdef TRITON_ENABLE_GPU
+#include "kernel.h"
+#endif  // TRITON_ENABLE_GPU
 
 namespace triton { namespace backend {
 //


### PR DESCRIPTION
@tanmayv25 This is needed to fix the build for when TRITON_ENABLE_GPU=OFF. It was caused by your change here https://github.com/triton-inference-server/backend/pull/22