### PR TITLE
ARM MALI support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,14 @@ target_compile_definitions(
 )
 endif() # TRITON_ENABLE_GPU
 
+# TRITON_ENABLE_GPU exposed in header so set PUBLIC
+if(${TRITON_ENABLE_MALI_GPU})
+target_compile_definitions(
+  triton-backend-utils
+  PUBLIC TRITON_ENABLE_MALI_GPU=1
+)
+endif() # TRITON_ENABLE_GPU
+
 # TRITON_ENABLE_STATS exposed in header so set PUBLIC
 if(${TRITON_ENABLE_STATS})
 target_compile_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ project(tritonbackend LANGUAGES C CXX)
 # Options
 #
 option(TRITON_ENABLE_GPU "Enable GPU support in backend utilities" ON)
+option(TRITON_ENABLE_MALI_GPU "Enable Arm MALI GPU support in backend utilities" OFF)
 option(TRITON_ENABLE_STATS "Include statistics collections in backend utilities" ON)
 
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ target_compile_definitions(
 )
 endif() # TRITON_ENABLE_GPU
 
-# TRITON_ENABLE_GPU exposed in header so set PUBLIC
+# TRITON_ENABLE_MALI_GPU exposed in header so set PUBLIC
 if(${TRITON_ENABLE_MALI_GPU})
 target_compile_definitions(
   triton-backend-utils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ target_compile_definitions(
   triton-backend-utils
   PUBLIC TRITON_ENABLE_MALI_GPU=1
 )
-endif() # TRITON_ENABLE_GPU
+endif() # TRITON_ENABLE_MALI_GPU
 
 # TRITON_ENABLE_STATS exposed in header so set PUBLIC
 if(${TRITON_ENABLE_STATS})

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -82,7 +82,7 @@ BackendModelInstance::BackendModelInstance(
       break;
     }
     case TRITONSERVER_INSTANCEGROUPKIND_GPU: {
-#ifdef TRITON_ENABLE_GPU
+#if defined (TRITON_ENABLE_GPU)
       cudaDeviceProp cuprops;
       cudaError_t cuerr = cudaGetDeviceProperties(&cuprops, device_id_);
       if (cuerr != cudaSuccess) {
@@ -108,7 +108,7 @@ BackendModelInstance::BackendModelInstance(
            std::to_string(device_id_) + " (" + cc + ") using artifact '" +
            artifact_filename_ + "'")
               .c_str());
-#else
+#elif ! defined (TRITON_ENABLE_MALI_GPU)
       throw BackendModelInstanceException(TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INTERNAL, "GPU instances not supported"));
 #endif  // TRITON_ENABLE_GPU


### PR DESCRIPTION
In supporting the Tensorflow Lite runtime with ArmNN, Arm Mali GPUs can be targeted on top of Cuda GPUs. When a user intends to accelerate the execution of a network on a MALI GPU, I have decided to keep the existing semantics with KIND_GPU, and added a new build flag for `TRITON_ENABLE_MALI_GPU`. This PR simply does a check for triton builds which target Arm MALI GPU systems such that an error is not thrown although the build disabled `TRITON_ENABLE_GPU`