### PR TITLE
Add copy on stream and nullify request pointers upon release

### DIFF
--- a/include/triton/backend/backend_common.h
+++ b/include/triton/backend/backend_common.h
@@ -237,6 +237,17 @@ class BatchOutput {
   std::vector<std::string> source_inputs_;
 };
 
+struct CopyParams {
+  CopyParams(void* dst, const void* src, const size_t byte_size)
+      : dst_(dst), src_(src), byte_size_(byte_size)
+  {
+  }
+
+  void* dst_;
+  const void* src_;
+  const size_t byte_size_;
+};
+
 /// The value for a dimension in a shape that indicates that that
 /// dimension can take on any size.
 constexpr int WILDCARD_DIM = -1;
@@ -422,13 +433,16 @@ void SendErrorForResponses(
 /// \param cuda_used returns whether a CUDA memory copy is initiated. If true,
 /// the caller should synchronize on the given 'cuda_stream' to ensure data copy
 /// is completed.
+/// \param copy_on_stream whether the memory copies should be performed in cuda
+/// host functions on the 'cuda_stream'.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* CopyBuffer(
     const std::string& msg, const TRITONSERVER_MemoryType src_memory_type,
     const int64_t src_memory_type_id,
     const TRITONSERVER_MemoryType dst_memory_type,
     const int64_t dst_memory_type_id, const size_t byte_size, const void* src,
-    void* dst, cudaStream_t cuda_stream, bool* cuda_used);
+    void* dst, cudaStream_t cuda_stream, bool* cuda_used,
+    const bool copy_on_stream = false);
 
 /// Does a file or directory exist?
 /// \param path The path to check for existance.

--- a/include/triton/backend/backend_common.h
+++ b/include/triton/backend/backend_common.h
@@ -399,7 +399,7 @@ TRITONSERVER_Error* GetTypedSequenceControlProperties(
 /// \param requests The requests.
 /// \param request_count The number of 'requests'.
 /// \param response_err The error to send to each request.
-/// \param release_request If true the requests will be released after
+/// \param release_request If true, the requests will be released after
 /// sending the error responses and the request pointers are set to
 /// nullptr.
 void RequestsRespondWithError(

--- a/include/triton/backend/backend_common.h
+++ b/include/triton/backend/backend_common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -389,7 +389,8 @@ TRITONSERVER_Error* GetTypedSequenceControlProperties(
 /// \param request_count The number of 'requests'.
 /// \param response_err The error to send to each request.
 /// \param release_request If true the requests will be released after
-/// sending the error responses.
+/// sending the error responses and the request pointers are set to
+/// nullptr.
 void RequestsRespondWithError(
     TRITONBACKEND_Request** requests, const uint32_t request_count,
     TRITONSERVER_Error* response_err, const bool release_request = true);

--- a/include/triton/backend/backend_input_collector.h
+++ b/include/triton/backend/backend_input_collector.h
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-=======
 // Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
->>>>>>> 45c8468... Add the support for copy on stream in backend utilities (#32)
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/include/triton/backend/backend_input_collector.h
+++ b/include/triton/backend/backend_input_collector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/include/triton/backend/backend_input_collector.h
+++ b/include/triton/backend/backend_input_collector.h
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 // Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+=======
+// Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+>>>>>>> 45c8468... Add the support for copy on stream in backend utilities (#32)
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -60,7 +64,7 @@ class BackendInputCollector {
       cudaStream_t stream, cudaEvent_t event = nullptr,
       cudaEvent_t buffer_ready_event = nullptr,
       const size_t kernel_buffer_threshold = 0,
-      const char* host_policy_name = nullptr)
+      const char* host_policy_name = nullptr, const bool copy_on_stream = false)
       : need_sync_(false), requests_(requests), request_count_(request_count),
         responses_(responses), memory_manager_(memory_manager),
         pinned_enabled_(pinned_enabled),
@@ -71,7 +75,7 @@ class BackendInputCollector {
         pending_copy_kernel_buffer_byte_size_(0),
         pending_copy_kernel_buffer_offset_(0),
         pending_copy_kernel_input_buffer_counts_(0), async_task_count_(0),
-        host_policy_cstr_(host_policy_name)
+        host_policy_cstr_(host_policy_name), copy_on_stream_(copy_on_stream)
   {
   }
 
@@ -190,8 +194,8 @@ class BackendInputCollector {
       const TRITONSERVER_MemoryType tensor_memory_type,
       const int64_t tensor_memory_type_id);
   bool SetInputTensor(
-      const char* input_name, const ContiguousBuffer& input, char* tensor_buffer,
-      const size_t tensor_buffer_byte_size,
+      const char* input_name, const ContiguousBuffer& input,
+      char* tensor_buffer, const size_t tensor_buffer_byte_size,
       const TRITONSERVER_MemoryType tensor_memory_type,
       const int64_t tensor_memory_type_id, const size_t tensor_buffer_offset,
       const TRITONSERVER_MemoryType use_pinned_memory_type,
@@ -242,15 +246,16 @@ class BackendInputCollector {
         char* pinned_memory, const size_t pinned_memory_size,
         char* tensor_buffer, const size_t tensor_buffer_offset,
         const TRITONSERVER_MemoryType tensor_memory_type,
-        const int64_t tensor_memory_id, std::list<ContiguousBuffer>&& request_buffers,
+        const int64_t tensor_memory_id,
+        std::list<ContiguousBuffer>&& request_buffers,
         std::vector<TRITONBACKEND_Response*>* responses)
         : finalized_(false), pinned_memory_(pinned_memory),
           pinned_memory_size_(pinned_memory_size),
           tensor_buffer_(tensor_buffer),
           tensor_buffer_offset_(tensor_buffer_offset),
           tensor_memory_type_(tensor_memory_type),
-          tensor_memory_id_(tensor_memory_id), requests_(std::move(request_buffers)),
-          responses_(responses)
+          tensor_memory_id_(tensor_memory_id),
+          requests_(std::move(request_buffers)), responses_(responses)
     {
     }
 
@@ -274,6 +279,7 @@ class BackendInputCollector {
   size_t async_task_count_;
 
   const char* host_policy_cstr_;
+  const bool copy_on_stream_;
 };
 
 }}  // namespace triton::backend

--- a/include/triton/backend/backend_output_responder.h
+++ b/include/triton/backend/backend_output_responder.h
@@ -54,12 +54,14 @@ class BackendOutputResponder {
       TRITONBACKEND_Request** requests, const uint32_t request_count,
       std::vector<TRITONBACKEND_Response*>* responses, const int max_batch_size,
       TRITONBACKEND_MemoryManager* memory_manager, const bool pinned_enabled,
-      cudaStream_t stream, cudaEvent_t event = nullptr)
+      cudaStream_t stream, cudaEvent_t event = nullptr,
+      bool copy_on_stream = false)
       : need_sync_(false), requests_(requests), request_count_(request_count),
         responses_(responses), max_batch_size_(max_batch_size),
         memory_manager_(memory_manager), pinned_enabled_(pinned_enabled),
         use_async_cpu_copy_(triton::common::AsyncWorkQueue::WorkerCount() > 1),
-        stream_(stream), event_(event), pending_pinned_byte_size_(0)
+        stream_(stream), event_(event), pending_pinned_byte_size_(0),
+        copy_on_stream_(copy_on_stream)
   {
   }
 
@@ -129,6 +131,7 @@ class BackendOutputResponder {
   size_t pending_pinned_byte_size_;
   size_t pending_pinned_offset_;
   ResponsesList pending_pinned_outputs_;
+  const bool copy_on_stream_;
 
   // Pinned memories that need to live over the lifetime of this
   // BackendOutputResponder object.

--- a/include/triton/backend/backend_output_responder.h
+++ b/include/triton/backend/backend_output_responder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -566,6 +566,7 @@ RequestsRespondWithError(
           TRITONBACKEND_RequestRelease(
               requests[i], TRITONSERVER_REQUEST_RELEASE_ALL),
           "fail to release request");
+      requests[i] = nullptr;
     }
   }
 

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -613,9 +613,9 @@ CopyBuffer(
 {
   *cuda_used = false;
 
-  // For CUDA memcpy, all host to host copy will be blocked in respect to the
-  // host, so use memcpy() directly. In this case, need to be careful on whether
-  // the src buffer is valid.
+  // For CUDA memcpy, if copy_on_stream is false, all host to host copy will be
+  // blocked in respect to the host, so use memcpy() directly. In this case,
+  // need to be careful on whether the src buffer is valid.
   if ((src_memory_type != TRITONSERVER_MEMORY_GPU) &&
       (dst_memory_type != TRITONSERVER_MEMORY_GPU)) {
 #ifdef TRITON_ENABLE_GPU

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -492,7 +492,7 @@ BackendInputCollector::SetInputTensor(
       input.memory_desc_.memory_type_id_, tensor_memory_type,
       tensor_memory_type_id, input.memory_desc_.byte_size_,
       input.memory_desc_.buffer_, tensor_buffer + tensor_buffer_offset, stream_,
-      &cuda_used);
+      &cuda_used, copy_on_stream_);
   if (err != nullptr) {
     for (size_t i = input.start_request_idx_; i <= input.end_request_idx_;
          ++i) {
@@ -588,7 +588,8 @@ BackendInputCollector::FlushPendingPinned(
             "pinned input buffer H2D", TRITONSERVER_MEMORY_CPU_PINNED,
             0 /* memory_type_id */, tensor_memory_type, tensor_memory_type_id,
             pending_pinned_byte_size_, pinned_memory,
-            tensor_buffer + pending_pinned_offset_, stream_, &cuda_used);
+            tensor_buffer + pending_pinned_offset_, stream_, &cuda_used,
+            copy_on_stream_);
         cuda_copy |= cuda_used;
 
         // If something goes wrong with the copy all the pending
@@ -738,6 +739,9 @@ BackendInputCollector::BatchInputShape(
       }
       break;
     }
+    default:
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INTERNAL, "unsupported BatchInputKind received");
   }
   return nullptr;  // success
 }
@@ -889,7 +893,8 @@ BackendInputCollector::ProcessBatchInput(
     RETURN_IF_ERROR(CopyBuffer(
         "batch input buffer", internal_buffer->MemoryType(),
         internal_buffer->MemoryTypeId(), *dst_memory_type, *dst_memory_type_id,
-        *dst_buffer_byte_size, input_buffer, buffer, stream_, &cuda_used));
+        *dst_buffer_byte_size, input_buffer, buffer, stream_, &cuda_used,
+        copy_on_stream_));
     // Need to keep the backend memory alive in the case of async copy
     in_use_memories_.emplace_back(std::move(internal_buffer));
     need_sync_ |= cuda_used;
@@ -1005,6 +1010,7 @@ BackendInputCollector::FlushPendingCopyKernel(
       offset += pr.memory_desc_.byte_size_;
     }
   }
+  TRITONSERVER_ErrorDelete(error);
 
   // Pending kernel copies are handled...
   pending_copy_kernel_buffer_byte_size_ = 0;

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions


### PR DESCRIPTION
Take note of the changes introduced by this commit. 
https://github.com/triton-inference-server/backend/commit/0d60470f89d9747907aa0daadc985493751545f2

TRT backend depends upon the requests being set to nullptr to prevent proceeding with the pipeline further down the line.