### PR TITLE
Read First Dimension Batching From Model Config

### DIFF
--- a/include/triton/backend/backend_model.h
+++ b/include/triton/backend/backend_model.h
@@ -115,7 +115,6 @@ class BackendModel {
   std::map<std::string, const BatchOutput*> batch_output_map_;
   std::set<std::string> ragged_inputs_;
   std::set<std::string> optional_inputs_;
-
 };
 
 //

--- a/include/triton/backend/backend_model.h
+++ b/include/triton/backend/backend_model.h
@@ -76,7 +76,7 @@ class BackendModel {
   void SetMaxBatchSize(const int b) { max_batch_size_ = b; }
 
   // Does this model support batching in the first dimension?
-  bool SupportsFirstDimBatching();
+  TRITONSERVER_Error* SupportsFirstDimBatching(bool* supports);
 
   // Use indirect pinned memory buffer when copying an input or output
   // tensor to/from the model.

--- a/include/triton/backend/backend_model.h
+++ b/include/triton/backend/backend_model.h
@@ -116,9 +116,6 @@ class BackendModel {
   std::set<std::string> ragged_inputs_;
   std::set<std::string> optional_inputs_;
 
-  // Does this model support batching in the first dimension.
-  bool supports_batching_initialized_;
-  bool supports_batching_;
 };
 
 //

--- a/include/triton/backend/backend_model.h
+++ b/include/triton/backend/backend_model.h
@@ -75,10 +75,8 @@ class BackendModel {
   // batch size.
   void SetMaxBatchSize(const int b) { max_batch_size_ = b; }
 
-  // Does this model support batching in the first dimension. If
-  // called before the model is completely loaded this function will
-  // return an error.
-  TRITONSERVER_Error* SupportsFirstDimBatching(bool* supports);
+  // Does this model support batching in the first dimension?
+  bool SupportsFirstDimBatching();
 
   // Use indirect pinned memory buffer when copying an input or output
   // tensor to/from the model.

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -153,7 +153,7 @@ BackendModel::BackendModel(
 bool
 BackendModel::SupportsFirstDimBatching()
 {
-  return (max_batch_size_ != 0);
+  return (max_batch_size_ > 0);
 }
 
 const BatchOutput*

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -152,7 +152,7 @@ BackendModel::BackendModel(
 TRITONSERVER_Error*
 BackendModel::SupportsFirstDimBatching(bool* supports)
 {
-  supports = max_batch_size_ > 0;
+  *supports = max_batch_size_ > 0;
   return nullptr;
 }
 

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -150,22 +150,10 @@ BackendModel::BackendModel(
   }
 }
 
-TRITONSERVER_Error*
-BackendModel::SupportsFirstDimBatching(bool* supports)
+bool
+BackendModel::SupportsFirstDimBatching()
 {
-  // We can't determine this during model initialization because
-  // TRITONSERVER_ServerModelBatchProperties can't be called until the
-  // model is loaded. So we just cache it here.
-  if (!supports_batching_initialized_) {
-    uint32_t flags = 0;
-    RETURN_IF_ERROR(TRITONSERVER_ServerModelBatchProperties(
-        triton_server_, name_.c_str(), version_, &flags, nullptr /* voidp */));
-    supports_batching_ = ((flags & TRITONSERVER_BATCH_FIRST_DIM) != 0);
-    supports_batching_initialized_ = true;
-  }
-
-  *supports = supports_batching_;
-  return nullptr;  // success
+  return (model_state_->MaxBatchSize() != 0);
 }
 
 const BatchOutput*

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -35,8 +35,7 @@ namespace triton { namespace backend {
 //
 BackendModel::BackendModel(
     TRITONBACKEND_Model* triton_model, const bool allow_optional)
-    : triton_model_(triton_model), supports_batching_initialized_(false),
-      supports_batching_(false)
+    : triton_model_(triton_model)
 {
   TRITONSERVER_Message* config_message;
   THROW_IF_BACKEND_MODEL_ERROR(TRITONBACKEND_ModelConfig(

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -149,10 +149,11 @@ BackendModel::BackendModel(
   }
 }
 
-bool
-BackendModel::SupportsFirstDimBatching()
+TRITONSERVER_Error*
+BackendModel::SupportsFirstDimBatching(bool* supports)
 {
-  return (max_batch_size_ > 0);
+  supports = max_batch_size_ > 0;
+  return nullptr;
 }
 
 const BatchOutput*

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -153,7 +153,7 @@ BackendModel::BackendModel(
 bool
 BackendModel::SupportsFirstDimBatching()
 {
-  return (model_state_->MaxBatchSize() != 0);
+  return (max_batch_size_ != 0);
 }
 
 const BatchOutput*

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -82,7 +82,7 @@ BackendModelInstance::BackendModelInstance(
       break;
     }
     case TRITONSERVER_INSTANCEGROUPKIND_GPU: {
-#if defined (TRITON_ENABLE_GPU)
+#if defined(TRITON_ENABLE_GPU)
       cudaDeviceProp cuprops;
       cudaError_t cuerr = cudaGetDeviceProperties(&cuprops, device_id_);
       if (cuerr != cudaSuccess) {
@@ -108,7 +108,7 @@ BackendModelInstance::BackendModelInstance(
            std::to_string(device_id_) + " (" + cc + ") using artifact '" +
            artifact_filename_ + "'")
               .c_str());
-#elif ! defined (TRITON_ENABLE_MALI_GPU)
+#elif !defined(TRITON_ENABLE_MALI_GPU)
       throw BackendModelInstanceException(TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INTERNAL, "GPU instances not supported"));
 #endif  // TRITON_ENABLE_GPU


### PR DESCRIPTION
Read whether the first dimension can be batched directly from the model config, using the logic of ServerModelBatchProperties without the extra fields or need for the model to already be loaded.

PRs in this change (merge together):
https://github.com/triton-inference-server/backend/pull/47
https://github.com/triton-inference-server/identity_backend/pull/15
https://github.com/triton-inference-server/server/pull/3692