### PR TITLE
Validate the batch size before trying to override it in responder

### DIFF
--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -648,6 +648,25 @@ CopyBuffer(
 {
   *cuda_used = false;
 
+  if ((src == nullptr) && (byte_size > 0)) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INTERNAL,
+        std::string(
+            msg + ": attempted a copy of " + std::to_string(byte_size) +
+            " Bytes from an uninitialized memory")
+            .c_str());
+  }
+
+  if ((dst == nullptr) && (byte_size > 0)) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INTERNAL,
+        std::string(
+            msg + ": attempted a copy of " + std::to_string(byte_size) +
+            " Bytes to an uninitialized memory")
+            .c_str());
+  }
+
+
   // For CUDA memcpy, if copy_on_stream is false, all host to host copy will be
   // blocked in respect to the host, so use memcpy() directly. In this case,
   // need to be careful on whether the src buffer is valid.

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -648,22 +648,24 @@ CopyBuffer(
 {
   *cuda_used = false;
 
-  if ((src == nullptr) && (byte_size > 0)) {
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INTERNAL,
-        std::string(
-            msg + ": attempted a copy of " + std::to_string(byte_size) +
-            " Bytes from an uninitialized memory")
-            .c_str());
-  }
+  if (byte_size > 0) {
+    if (src == nullptr) {
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INTERNAL,
+          std::string(
+              msg + ": attempted a copy of " + std::to_string(byte_size) +
+              " Bytes from an uninitialized memory")
+              .c_str());
+    }
 
-  if ((dst == nullptr) && (byte_size > 0)) {
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INTERNAL,
-        std::string(
-            msg + ": attempted a copy of " + std::to_string(byte_size) +
-            " Bytes to an uninitialized memory")
-            .c_str());
+    if (dst == nullptr) {
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INTERNAL,
+          std::string(
+              msg + ": attempted a copy of " + std::to_string(byte_size) +
+              " Bytes to an uninitialized memory")
+              .c_str());
+    }
   }
 
 

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -96,8 +96,8 @@ BackendOutputResponder::ProcessTensor(
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   std::string(
-                      "failed to split the output tensor `" + output_name +
-                      "` in responses: expected batch size of atleast " +
+                      "failed to split the output tensor '" + output_name +
+                      "' in responses: expected batch size of atleast " +
                       std::to_string(batch_size_offset + shape[0]) +
                       " in model output, got " +
                       std::to_string(batchn_batch_size))
@@ -203,9 +203,9 @@ BackendOutputResponder::ProcessStateTensor(
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   std::string(
-                      "failed to split the output state tensor `" +
+                      "failed to split the output state tensor '" +
                       output_state_name +
-                      "` in responses: expected batch size of atleast " +
+                      "' in responses: expected batch size of atleast " +
                       std::to_string(batch_size_offset + shape[0]) +
                       " in model output, got " +
                       std::to_string(batchn_batch_size))


### PR DESCRIPTION
Will throw and error if unexpected batch size is found in the output tensor.
See here for more information: https://github.com/triton-inference-server/tensorflow_backend/pull/56