### PR TITLE
Prefix Logs with Request ID

### DIFF
--- a/include/triton/backend/backend_common.h
+++ b/include/triton/backend/backend_common.h
@@ -663,4 +663,10 @@ TRITONSERVER_Error* BufferAsTypedString(
     std::string& str, const char* buffer, size_t buffer_byte_size,
     TRITONSERVER_DataType datatype);
 
+/// Get the ID of the request as a string formatted for logging.
+///
+/// \param request Request of which to get the ID.
+/// \return a formatted string for logging the request ID.
+std::string GetRequestId(TRITONBACKEND_Request* request);
+
 }}  // namespace triton::backend

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -217,12 +217,12 @@ ReadInputTensor(
   RETURN_IF_ERROR(TRITONBACKEND_InputPropertiesForHostPolicy(
       input, host_policy_name, nullptr, nullptr, nullptr, nullptr,
       &input_byte_size, &input_buffer_count));
+  const char* request_id;
+  LOG_IF_ERR(
+      TRITONSERVER_InferenceRequestIdString(request, &request_id),
+      "unable to get request ID string");
   RETURN_ERROR_IF_FALSE(
       input_byte_size <= *buffer_byte_size, TRITONSERVER_ERROR_INVALID_ARG,
-      const char* request_id;
-      LOG_IF_ERR(
-          TRITONSERVER_InferenceRequestIdString(requests[i], &request_id),
-          "unable to get request ID string");
       std::string(
           request_id + "buffer too small for input tensor '" + input_name +
           "', " + std::to_string(*buffer_byte_size) + " < " +

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -224,8 +224,8 @@ ReadInputTensor(
   RETURN_ERROR_IF_FALSE(
       input_byte_size <= *buffer_byte_size, TRITONSERVER_ERROR_INVALID_ARG,
       std::string(
-          request_id + "buffer too small for input tensor '" + input_name +
-          "', " + std::to_string(*buffer_byte_size) + " < " +
+          std::string(request_id) + "buffer too small for input tensor '" +
+          input_name + "', " + std::to_string(*buffer_byte_size) + " < " +
           std::to_string(input_byte_size)));
 
   size_t output_buffer_offset = 0;

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -1365,7 +1365,7 @@ GetRequestId(TRITONBACKEND_Request* request)
   LOG_IF_ERROR(
       TRITONBACKEND_RequestId(request, &request_id),
       "unable to retrieve request ID string");
-  if (request_id == nullptr || * request_id = 0) {
+  if (request_id == nullptr || *request_id == 0) {
     request_id = "<id_unknown>";
   }
   return std::string("[request id: ") + request_id + "]";

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -1361,15 +1361,11 @@ BufferAsTypedString(
 std::string
 GetRequestId(TRITONBACKEND_Request* request)
 {
-  const char* request_id = nullptr;
+  const char* request_id = "<id_unknown>";
   LOG_IF_ERROR(
-      TRITONBACKEND_RequestIdString(request, &request_id),
+      TRITONBACKEND_RequestId(request, &request_id),
       "unable to get request ID string");
-  if (request_id != nullptr) {
-    return std::string("[request id: ") + Id() + "]";
-  } else {
-    return "";
-  }
+  return std::string("[request id: ") + request_id + "]";
 }
 
 }}  // namespace triton::backend

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -1365,7 +1365,7 @@ GetRequestId(TRITONBACKEND_Request* request)
   LOG_IF_ERROR(
       TRITONBACKEND_RequestId(request, &request_id),
       "unable to retrieve request ID string");
-  if (request_id == nullptr || request_id[0] != '\0') {
+  if ((request_id == nullptr) || (request_id[0] == '\0')) {
     request_id = "<id_unknown>";
   }
   return std::string("[request id: ") + request_id + "]";

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -217,7 +217,7 @@ ReadInputTensor(
   RETURN_IF_ERROR(TRITONBACKEND_InputPropertiesForHostPolicy(
       input, host_policy_name, nullptr, nullptr, nullptr, nullptr,
       &input_byte_size, &input_buffer_count));
-  const char* request_id;
+  const char* request_id = "";
   LOG_IF_ERROR(
       TRITONBACKEND_RequestIdString(request, &request_id),
       "unable to get request ID string");
@@ -615,7 +615,7 @@ RequestsRespondWithError(
   for (size_t i = 0; i < request_count; i++) {
     TRITONBACKEND_Response* response;
     auto err = TRITONBACKEND_ResponseNew(&response, requests[i]);
-    const char* request_id;
+    const char* request_id = "";
     LOG_IF_ERROR(
         TRITONBACKEND_RequestIdString(requests[i], &request_id),
         "unable to get request ID string");

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -1368,7 +1368,7 @@ GetRequestId(TRITONBACKEND_Request* request)
   if ((request_id == nullptr) || (request_id[0] == '\0')) {
     request_id = "<id_unknown>";
   }
-  return std::string("[request id: ") + request_id + "]";
+  return std::string("[request id: ") + request_id + "] ";
 }
 
 }}  // namespace triton::backend

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -1361,11 +1361,11 @@ BufferAsTypedString(
 std::string
 GetRequestId(TRITONBACKEND_Request* request)
 {
-  const char* request_id;
+  const char* request_id = nullptr;
   LOG_IF_ERROR(
       TRITONBACKEND_RequestId(request, &request_id),
       "unable to retrieve request ID string");
-  if (request_id == nullptr || *request_id == 0) {
+  if (request_id == nullptr || request_id[0] != '\0') {
     request_id = "<id_unknown>";
   }
   return std::string("[request id: ") + request_id + "]";

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -220,7 +220,7 @@ ReadInputTensor(
   RETURN_ERROR_IF_FALSE(
       input_byte_size <= *buffer_byte_size, TRITONSERVER_ERROR_INVALID_ARG,
       std::string(
-          "buffer too small for input tensor '" + input_name + "', " +
+          request->IdString() + "buffer too small for input tensor '" + input_name + "', " +
           std::to_string(*buffer_byte_size) + " < " +
           std::to_string(input_byte_size)));
 
@@ -612,13 +612,13 @@ RequestsRespondWithError(
     TRITONBACKEND_Response* response;
     auto err = TRITONBACKEND_ResponseNew(&response, requests[i]);
     if (err != nullptr) {
-      LOG_MESSAGE(TRITONSERVER_LOG_ERROR, "fail to create response");
+      LOG_MESSAGE(TRITONSERVER_LOG_ERROR, (requests[i].IdString() + "fail to create response").c_str());
       TRITONSERVER_ErrorDelete(err);
     } else {
       LOG_IF_ERROR(
           TRITONBACKEND_ResponseSend(
               response, TRITONSERVER_RESPONSE_COMPLETE_FINAL, response_err),
-          "fail to send error response");
+          (requests[i].IdString() + "fail to send error response").c_str());
     }
 
     if (release_request) {

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -1361,10 +1361,13 @@ BufferAsTypedString(
 std::string
 GetRequestId(TRITONBACKEND_Request* request)
 {
-  const char* request_id = "<id_unknown>";
+  const char* request_id;
   LOG_IF_ERROR(
       TRITONBACKEND_RequestId(request, &request_id),
-      "unable to get request ID string");
+      "unable to retrieve request ID string");
+  if (request_id == nullptr || * request_id = 0) {
+    request_id = "<id_unknown>";
+  }
   return std::string("[request id: ") + request_id + "]";
 }
 

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -612,13 +612,13 @@ RequestsRespondWithError(
     TRITONBACKEND_Response* response;
     auto err = TRITONBACKEND_ResponseNew(&response, requests[i]);
     if (err != nullptr) {
-      LOG_MESSAGE(TRITONSERVER_LOG_ERROR, (requests[i].IdString() + "fail to create response").c_str());
+      LOG_MESSAGE(TRITONSERVER_LOG_ERROR, (requests[i]->IdString() + "fail to create response").c_str());
       TRITONSERVER_ErrorDelete(err);
     } else {
       LOG_IF_ERROR(
           TRITONBACKEND_ResponseSend(
               response, TRITONSERVER_RESPONSE_COMPLETE_FINAL, response_err),
-          (requests[i].IdString() + "fail to send error response").c_str());
+          (requests[i]->IdString() + "fail to send error response").c_str());
     }
 
     if (release_request) {

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -1361,11 +1361,15 @@ BufferAsTypedString(
 std::string
 GetRequestId(TRITONBACKEND_Request* request)
 {
-  const char* request_id = "";
+  const char* request_id = nullptr;
   LOG_IF_ERROR(
       TRITONBACKEND_RequestIdString(request, &request_id),
       "unable to get request ID string");
-  return std::string(request_id);
+  if (request_id != nullptr) {
+    return std::string("[request id: ") + Id() + "]";
+  } else {
+    return "";
+  }
 }
 
 }}  // namespace triton::backend

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -219,7 +219,7 @@ ReadInputTensor(
       &input_byte_size, &input_buffer_count));
   const char* request_id;
   LOG_IF_ERROR(
-      TRITONSERVER_InferenceRequestIdString(request, &request_id),
+      TRITONBACKEND_RequestIdString(request, &request_id),
       "unable to get request ID string");
   RETURN_ERROR_IF_FALSE(
       input_byte_size <= *buffer_byte_size, TRITONSERVER_ERROR_INVALID_ARG,
@@ -617,7 +617,7 @@ RequestsRespondWithError(
     auto err = TRITONBACKEND_ResponseNew(&response, requests[i]);
     const char* request_id;
     LOG_IF_ERROR(
-        TRITONSERVER_InferenceRequestIdString(requests[i], &request_id),
+        TRITONBACKEND_RequestIdString(requests[i], &request_id),
         "unable to get request ID string");
     if (err != nullptr) {
       LOG_MESSAGE(

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -218,7 +218,7 @@ ReadInputTensor(
       input, host_policy_name, nullptr, nullptr, nullptr, nullptr,
       &input_byte_size, &input_buffer_count));
   const char* request_id;
-  LOG_IF_ERR(
+  LOG_IF_ERROR(
       TRITONSERVER_InferenceRequestIdString(request, &request_id),
       "unable to get request ID string");
   RETURN_ERROR_IF_FALSE(
@@ -616,7 +616,7 @@ RequestsRespondWithError(
     TRITONBACKEND_Response* response;
     auto err = TRITONBACKEND_ResponseNew(&response, requests[i]);
     const char* request_id;
-    LOG_IF_ERR(
+    LOG_IF_ERROR(
         TRITONSERVER_InferenceRequestIdString(requests[i], &request_id),
         "unable to get request ID string");
     if (err != nullptr) {

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -1076,13 +1076,9 @@ BackendInputCollector::SetBatchItemShape(
     // for batching enabled model.
     size_t batch_1_size = sizeof(T) * (dims_count - 1);
     if (buffer_offset + (size_t)shape[0] * batch_1_size > buffer_byte_size) {
-      const char* request_id = "";
-      LOG_IF_ERROR(
-          TRITONBACKEND_RequestIdString(requests_[req_idx], &request_id),
-          "unable to get request ID string");
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
-          (std::string(request_id) +
+          (GetRequestId(requests_[req_idx]) +
            "unexpected total byte size for batch input")
               .c_str());
     }

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -1078,7 +1078,7 @@ BackendInputCollector::SetBatchItemShape(
     if (buffer_offset + (size_t)shape[0] * batch_1_size > buffer_byte_size) {
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
-          "unexpected total byte size for batch input");
+          (requests_[req_idx].IdString() + "unexpected total byte size for batch input").c_str());
     }
     // The batch input tracks the shape without batch dimension for
     // each batch item

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -1076,10 +1076,9 @@ BackendInputCollector::SetBatchItemShape(
     // for batching enabled model.
     size_t batch_1_size = sizeof(T) * (dims_count - 1);
     if (buffer_offset + (size_t)shape[0] * batch_1_size > buffer_byte_size) {
-      const char* request_id;
+      const char* request_id = "";
       LOG_IF_ERROR(
-          TRITONBACKEND_RequestIdString(
-              requests_[req_idx], &request_id),
+          TRITONBACKEND_RequestIdString(requests_[req_idx], &request_id),
           "unable to get request ID string");
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -1076,9 +1076,16 @@ BackendInputCollector::SetBatchItemShape(
     // for batching enabled model.
     size_t batch_1_size = sizeof(T) * (dims_count - 1);
     if (buffer_offset + (size_t)shape[0] * batch_1_size > buffer_byte_size) {
+      const char* request_id;
+      LOG_IF_ERR(
+          TRITONSERVER_InferenceRequestIdString(
+              requests_[req_idx], &request_id),
+          "unable to get request ID string");
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
-          (requests_[req_idx]->IdString() + "unexpected total byte size for batch input").c_str());
+          (std::string(request_id) +
+           "unexpected total byte size for batch input")
+              .c_str());
     }
     // The batch input tracks the shape without batch dimension for
     // each batch item

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -1077,7 +1077,7 @@ BackendInputCollector::SetBatchItemShape(
     size_t batch_1_size = sizeof(T) * (dims_count - 1);
     if (buffer_offset + (size_t)shape[0] * batch_1_size > buffer_byte_size) {
       const char* request_id;
-      LOG_IF_ERR(
+      LOG_IF_ERROR(
           TRITONSERVER_InferenceRequestIdString(
               requests_[req_idx], &request_id),
           "unable to get request ID string");

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -1078,7 +1078,7 @@ BackendInputCollector::SetBatchItemShape(
     if (buffer_offset + (size_t)shape[0] * batch_1_size > buffer_byte_size) {
       const char* request_id;
       LOG_IF_ERROR(
-          TRITONSERVER_InferenceRequestIdString(
+          TRITONBACKEND_RequestIdString(
               requests_[req_idx], &request_id),
           "unable to get request ID string");
       return TRITONSERVER_ErrorNew(

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -1078,7 +1078,7 @@ BackendInputCollector::SetBatchItemShape(
     if (buffer_offset + (size_t)shape[0] * batch_1_size > buffer_byte_size) {
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
-          (requests_[req_idx].IdString() + "unexpected total byte size for batch input").c_str());
+          (requests_[req_idx]->IdString() + "unexpected total byte size for batch input").c_str());
     }
     // The batch input tracks the shape without batch dimension for
     // each batch item

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -93,7 +93,7 @@ BackendOutputResponder::ProcessTensor(
         if (response != nullptr) {
           const char* request_id;
           LOG_IF_ERROR(
-              TRITONSERVER_InferenceRequestIdString(request, &request_id),
+              TRITONBACKEND_RequestIdString(request, &request_id),
               "unable to get request ID string");
           RESPOND_AND_SET_NULL_IF_ERROR(
               &response,
@@ -205,7 +205,7 @@ BackendOutputResponder::ProcessStateTensor(
         if (response != nullptr) {
           const char* request_id;
           LOG_IF_ERROR(
-              TRITONSERVER_InferenceRequestIdString(request, &request_id),
+              TRITONBACKEND_RequestIdString(request, &request_id),
               "unable to get request ID string");
           RESPOND_AND_SET_NULL_IF_ERROR(
               &response,

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -96,7 +96,7 @@ BackendOutputResponder::ProcessTensor(
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   std::string(
-                      request.IdString() +
+                      request->IdString() +
                       "failed to split the output tensor '" + output_name +
                       "' in responses: expected batch size of atleast " +
                       std::to_string(batch_size_offset + shape[0]) +
@@ -204,7 +204,7 @@ BackendOutputResponder::ProcessStateTensor(
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   std::string(
-                      request.IdString() + 
+                      request->IdString() + 
                       "failed to split the output state tensor '" +
                       output_state_name +
                       "' in responses: expected batch size of atleast " +

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -96,6 +96,7 @@ BackendOutputResponder::ProcessTensor(
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   std::string(
+                      request.IdString() +
                       "failed to split the output tensor '" + output_name +
                       "' in responses: expected batch size of atleast " +
                       std::to_string(batch_size_offset + shape[0]) +
@@ -203,6 +204,7 @@ BackendOutputResponder::ProcessStateTensor(
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   std::string(
+                      request.IdString() + 
                       "failed to split the output state tensor '" +
                       output_state_name +
                       "' in responses: expected batch size of atleast " +

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -205,7 +205,7 @@ BackendOutputResponder::ProcessStateTensor(
         if (response != nullptr) {
           const char* request_id;
           LOG_IF_ERROR(
-              TRITONSERVER_InferenceRequestIdString(requests[i], &request_id),
+              TRITONSERVER_InferenceRequestIdString(request, &request_id),
               "unable to get request ID string");
           RESPOND_AND_SET_NULL_IF_ERROR(
               &response,

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -91,12 +91,16 @@ BackendOutputResponder::ProcessTensor(
       if ((batchn_batch_size != -1) &&
           ((batch_size_offset + shape[0]) > batchn_batch_size)) {
         if (response != nullptr) {
+          const char* request_id;
+          LOG_IF_ERR(
+              TRITONSERVER_InferenceRequestIdString(requests[i], &request_id),
+              "unable to get request ID string");
           RESPOND_AND_SET_NULL_IF_ERROR(
               &response,
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   std::string(
-                      request->IdString() +
+                      std::string(request_id) +
                       "failed to split the output tensor '" + output_name +
                       "' in responses: expected batch size of atleast " +
                       std::to_string(batch_size_offset + shape[0]) +
@@ -199,12 +203,16 @@ BackendOutputResponder::ProcessStateTensor(
       if ((batchn_batch_size != -1) &&
           ((batch_size_offset + shape[0]) > batchn_batch_size)) {
         if (response != nullptr) {
+          const char* request_id;
+          LOG_IF_ERR(
+              TRITONSERVER_InferenceRequestIdString(requests[i], &request_id),
+              "unable to get request ID string");
           RESPOND_AND_SET_NULL_IF_ERROR(
               &response,
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   std::string(
-                      request->IdString() + 
+                      std::string(request_id) +
                       "failed to split the output state tensor '" +
                       output_state_name +
                       "' in responses: expected batch size of atleast " +

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -91,7 +91,7 @@ BackendOutputResponder::ProcessTensor(
       if ((batchn_batch_size != -1) &&
           ((batch_size_offset + shape[0]) > batchn_batch_size)) {
         if (response != nullptr) {
-          const char* request_id;
+          const char* request_id = "";
           LOG_IF_ERROR(
               TRITONBACKEND_RequestIdString(request, &request_id),
               "unable to get request ID string");
@@ -203,7 +203,7 @@ BackendOutputResponder::ProcessStateTensor(
       if ((batchn_batch_size != -1) &&
           ((batch_size_offset + shape[0]) > batchn_batch_size)) {
         if (response != nullptr) {
-          const char* request_id;
+          const char* request_id = "";
           LOG_IF_ERROR(
               TRITONBACKEND_RequestIdString(request, &request_id),
               "unable to get request ID string");

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -91,16 +91,12 @@ BackendOutputResponder::ProcessTensor(
       if ((batchn_batch_size != -1) &&
           ((batch_size_offset + shape[0]) > batchn_batch_size)) {
         if (response != nullptr) {
-          const char* request_id = "";
-          LOG_IF_ERROR(
-              TRITONBACKEND_RequestIdString(request, &request_id),
-              "unable to get request ID string");
           RESPOND_AND_SET_NULL_IF_ERROR(
               &response,
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   std::string(
-                      std::string(request_id) +
+                      GetRequestId(request) +
                       "failed to split the output tensor '" + output_name +
                       "' in responses: expected batch size of atleast " +
                       std::to_string(batch_size_offset + shape[0]) +
@@ -203,16 +199,12 @@ BackendOutputResponder::ProcessStateTensor(
       if ((batchn_batch_size != -1) &&
           ((batch_size_offset + shape[0]) > batchn_batch_size)) {
         if (response != nullptr) {
-          const char* request_id = "";
-          LOG_IF_ERROR(
-              TRITONBACKEND_RequestIdString(request, &request_id),
-              "unable to get request ID string");
           RESPOND_AND_SET_NULL_IF_ERROR(
               &response,
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   std::string(
-                      std::string(request_id) +
+                      GetRequestId(request) +
                       "failed to split the output state tensor '" +
                       output_state_name +
                       "' in responses: expected batch size of atleast " +

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -92,8 +92,8 @@ BackendOutputResponder::ProcessTensor(
           ((batch_size_offset + shape[0]) > batchn_batch_size)) {
         if (response != nullptr) {
           const char* request_id;
-          LOG_IF_ERR(
-              TRITONSERVER_InferenceRequestIdString(requests[i], &request_id),
+          LOG_IF_ERROR(
+              TRITONSERVER_InferenceRequestIdString(request, &request_id),
               "unable to get request ID string");
           RESPOND_AND_SET_NULL_IF_ERROR(
               &response,
@@ -204,7 +204,7 @@ BackendOutputResponder::ProcessStateTensor(
           ((batch_size_offset + shape[0]) > batchn_batch_size)) {
         if (response != nullptr) {
           const char* request_id;
-          LOG_IF_ERR(
+          LOG_IF_ERROR(
               TRITONSERVER_InferenceRequestIdString(requests[i], &request_id),
               "unable to get request ID string");
           RESPOND_AND_SET_NULL_IF_ERROR(


### PR DESCRIPTION
Prefix logs with the request ID, where possible.

Related changes:
Core: https://github.com/triton-inference-server/core/pull/85
Server: https://github.com/triton-inference-server/server/pull/4484