### PR TITLE
feat: update readme, with that plattform field is legacy and backend is prefered

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ requests to the backend for execution and the backend uses the API to
 communicate with Triton.
 
 Every model must be associated with a backend. A model's backend is
-specified in the model's configuration using the 'backend' and
-'platform' settings. Depending on the backend one or the other of
+specified in the model's configuration using the 'backend'(recommended) and
+'platform'(legacy field supported for backward compatibility) settings. Depending on the backend one or the other of
 these properties is optional.
 
 * For TensorRT, 'backend' must be set to *tensorrt* or 'platform' must

--- a/README.md
+++ b/README.md
@@ -152,25 +152,18 @@ requests to the backend for execution and the backend uses the API to
 communicate with Triton.
 
 Every model must be associated with a backend. A model's backend is
-specified in the model's configuration using the 'backend'(recommended) and
-'platform'(legacy field supported for backward compatibility) settings. Depending on the backend one or the other of
-these properties is optional.
+specified in the model's configuration using the 'backend' setting. 
 
-* For TensorRT, 'backend' must be set to *tensorrt* or 'platform' must
-  be set to *tensorrt_plan*.
+* For TensorRT, 'backend' must be set to *tensorrt*.
 
-* For PyTorch, 'backend' must be set to *pytorch* or 'platform' must
-  be set to *pytorch_libtorch*.
+* For PyTorch, 'backend' must be set to *pytorch*.
 
-* For ONNX, 'backend' must be set to *onnxruntime* or 'platform' must
-  be set to *onnxruntime_onnx*.
+* For ONNX, 'backend' must be set to *onnxruntime*.
 
-* For TensorFlow, 'platform must be set to *tensorflow_graphdef* or
-  *tensorflow_savedmodel*. Optionally 'backend' can be set to
-  *tensorflow*.
+* For TensorFlow, 'backend' must be set to *tensorflow*.
 
 * For all other backends, 'backend' must be set to the name of the
-  backend and 'platform' is optional.
+  backend.
 
 ### Backend Shared Library
 

--- a/README.md
+++ b/README.md
@@ -152,18 +152,7 @@ requests to the backend for execution and the backend uses the API to
 communicate with Triton.
 
 Every model must be associated with a backend. A model's backend is
-specified in the model's configuration using the 'backend' setting. 
-
-* For TensorRT, 'backend' must be set to *tensorrt*.
-
-* For PyTorch, 'backend' must be set to *pytorch*.
-
-* For ONNX, 'backend' must be set to *onnxruntime*.
-
-* For TensorFlow, 'backend' must be set to *tensorflow*.
-
-* For all other backends, 'backend' must be set to the name of the
-  backend.
+specified in the model's configuration using the 'backend' setting. For using TensorRT backend, the value of this setting should be *tensorrt*. Similarly, for using PyTorch, ONNX and TensorFlow Backends, the `backend` field should be set to *pytorch*, *onnxruntime* or *tensorflow* respectively.
 
 ### Backend Shared Library
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,11 @@ requests to the backend for execution and the backend uses the API to
 communicate with Triton.
 
 Every model must be associated with a backend. A model's backend is
-specified in the model's configuration using the 'backend' setting. For using TensorRT backend, the value of this setting should be *tensorrt*. Similarly, for using PyTorch, ONNX and TensorFlow Backends, the `backend` field should be set to *pytorch*, *onnxruntime* or *tensorflow* respectively.
+specified in the model's configuration using the 'backend' setting. 
+For using TensorRT backend, the value of this setting should be *tensorrt*. 
+Similarly, for using PyTorch, ONNX and TensorFlow Backends, the `backend` 
+field should be set to *pytorch*, *onnxruntime* or *tensorflow* respectively. 
+For all other backends, 'backend' must be set to the name of the backend.
 
 ### Backend Shared Library
 


### PR DESCRIPTION
Updated `README.md` based upon https://github.com/triton-inference-server/server/issues/4672