### PR TITLE
Fixed the casting issue for armv7

### DIFF
--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -69,7 +69,7 @@ BackendInputCollector::InputIterator::GetNextContiguousInput(
   TRITONBACKEND_InputBufferForHostPolicy(
       curr_input_, host_policy_, curr_buffer_idx_,
       reinterpret_cast<const void**>(&input->memory_desc_.buffer_),
-      &input->memory_desc_.byte_size_, &input->memory_desc_.memory_type_,
+      reinterpret_cast<uint64_t*>(&input->memory_desc_.byte_size_), &input->memory_desc_.memory_type_,
       &input->memory_desc_.memory_type_id_);
   ++curr_buffer_idx_;
   input->start_request_idx_ = curr_request_idx_;
@@ -104,7 +104,7 @@ BackendInputCollector::InputIterator::GetNextContiguousInput(
       int64_t next_memory_type_id;
       TRITONBACKEND_InputBufferForHostPolicy(
           curr_input_, host_policy_, curr_buffer_idx_, &next_buffer,
-          &next_buffer_byte_size, &next_memory_type, &next_memory_type_id);
+          reinterpret_cast<uint64_t*>(&next_buffer_byte_size), &next_memory_type, &next_memory_type_id);
       if (((input->memory_desc_.buffer_ + input->memory_desc_.byte_size_) !=
            next_buffer) ||
           (input->memory_desc_.memory_type_ != next_memory_type) ||
@@ -169,7 +169,7 @@ BackendInputCollector::GetInputBufferIfContiguous(
       RESPOND_AND_SET_NULL_IF_ERROR(
           &response,
           TRITONBACKEND_InputBufferForHostPolicy(
-              input, host_policy_cstr_, idx, &src_buffer, &src_byte_size,
+              input, host_policy_cstr_, idx, &src_buffer, reinterpret_cast<uint64_t*>(&src_byte_size),
               &src_memory_type, &src_memory_type_id));
       if (*buffer != nullptr) {
         // If have seen the second buffer while coalescing input is not


### PR DESCRIPTION
I intend on using the Triton Inference server on 3 devices (amd64, arm64 and arm/v7). After trying to build the server for my arm/v7 device, I noticed that there where casting errors. I realized that I needed to make similar fixes in the core and server repositories as well. Once all the casting issues have been solved in the 3 repos, I was able to correctly run inferences on all three of my devices.