### PR TITLE
Add Cache Function for User-Defined Batching

### DIFF
--- a/examples/batching_strategies/single_batching/src/single_batching.cc
+++ b/examples/batching_strategies/single_batching/src/single_batching.cc
@@ -72,7 +72,8 @@ TRITONBACKEND_ModelBatchIncludeRequest(
 /// about this pending batch.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error*
-TRITONBACKEND_ModelBatchInitialize(TRITONBACKEND_Model* model, void** userp)
+TRITONBACKEND_ModelBatchInitialize(
+    TRITONBACKEND_Model* model, void** userp, void** cache_userp)
 {
   // Userp will point to a boolean indicating whether the batch is empty.
   *userp = new bool(true);
@@ -87,7 +88,6 @@ TRITONSERVER_Error*
 TRITONBACKEND_ModelBatchFinalize(void* userp)
 {
   delete static_cast<bool*>(userp);
-
   return nullptr;  // success
 }
 

--- a/examples/batching_strategies/single_batching/src/single_batching.cc
+++ b/examples/batching_strategies/single_batching/src/single_batching.cc
@@ -73,7 +73,7 @@ TRITONBACKEND_ModelBatchIncludeRequest(
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error*
 TRITONBACKEND_ModelBatchInitialize(
-    TRITONBACKEND_Model* model, void** userp, void** cache_userp)
+    TRITONBACKEND_Model* model, void** userp, const void* cache_userp)
 {
   // Userp will point to a boolean indicating whether the batch is empty.
   *userp = new bool(true);

--- a/examples/batching_strategies/volume_batching/src/volume_batching.cc
+++ b/examples/batching_strategies/volume_batching/src/volume_batching.cc
@@ -194,6 +194,7 @@ TRITONBACKEND_ModelBatchCacheInitialize(
   }
 
   *cache_userp = new unsigned int(max_volume_bytes);
+  return nullptr;  // success
 }
 
 /// Callback to be invoked when Triton unloads model.
@@ -204,6 +205,7 @@ TRITONSERVER_Error*
 TRITONBACKEND_ModelBatchCacheFinalize(void* cache_userp)
 {
   delete static_cast<unsigned int*>(cache_userp);
+  return nullptr;  // success
 }
 
 }  // extern "C"

--- a/examples/batching_strategies/volume_batching/src/volume_batching.cc
+++ b/examples/batching_strategies/volume_batching/src/volume_batching.cc
@@ -198,8 +198,8 @@ TRITONBACKEND_ModelBatchCacheInitialize(
 
 /// Callback to be invoked when Triton unloads model.
 /// \param cache_userp The placeholder for backend to store and retrieve
-/// information about the batching strategy for this model. \return a
-/// TRITONSERVER_Error indicating success or failure.
+/// information about the batching strategy for this model.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error*
 TRITONBACKEND_ModelBatchCacheFinalize(void* cache_userp)
 {

--- a/examples/batching_strategies/volume_batching/src/volume_batching.cc
+++ b/examples/batching_strategies/volume_batching/src/volume_batching.cc
@@ -132,12 +132,14 @@ TRITONBACKEND_ModelBatchFinalize(void* userp)
   return nullptr;  // success
 }
 
-/// Callback to be invoked when Triton loads model.
+/// Callback to be invoked when Triton loads the model.
 /// This will hold a cached user pointer that can be read during custom
-/// batching. \param model The backend model for which Triton is forming a
-/// batch. \param cache_userp The placeholder for backend to store and retrieve
-/// information about the batching strategy for this model. \return a
-/// TRITONSERVER_Error indicating success or failure.
+/// batching.
+/// \param model The backend model for which Triton is forming a
+/// batch.
+/// \param cache_userp The placeholder for thebackend to store and
+/// retrieve information about the batching strategy for this model.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error*
 TRITONBACKEND_ModelBatchCacheInitialize(
     TRITONBACKEND_Model* model, void** cache_userp)
@@ -196,7 +198,7 @@ TRITONBACKEND_ModelBatchCacheInitialize(
   return nullptr;  // success
 }
 
-/// Callback to be invoked when Triton unloads model.
+/// Callback to be invoked when Triton unloads the model.
 /// \param cache_userp The placeholder for backend to store and retrieve
 /// information about the batching strategy for this model.
 /// \return a TRITONSERVER_Error indicating success or failure.

--- a/examples/batching_strategies/volume_batching/src/volume_batching.cc
+++ b/examples/batching_strategies/volume_batching/src/volume_batching.cc
@@ -113,12 +113,11 @@ TRITONBACKEND_ModelBatchIncludeRequest(
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error*
 TRITONBACKEND_ModelBatchInitialize(
-    TRITONBACKEND_Model* model, void** userp, void** cache_userp)
+    TRITONBACKEND_Model* model, void** userp, const void* cache_userp)
 {
   // Userp will point to an unsigned integer representing the remaining volume
   // in bytes for this batch.
-
-  *userp = new unsigned int(*static_cast<unsigned int*>(*cache_userp));
+  *userp = new unsigned int(*static_cast<const unsigned int*>(cache_userp));
   return nullptr;  // success
 }
 


### PR DESCRIPTION
This PR builds on https://github.com/triton-inference-server/backend/pull/75. For custom batching where the user defines additional constraints for the dynamic batcher, this PR allows the user to call two new optional functions that initialize and finalize once. This allows them to create a cached object that can be read for every batch without needing to be re-initialized.

An example use case is where the user needs to read a value from the model config for batching, so they would only want to read it from the config once and save it to use with their custom batch-handling logic. See volume_batching.cc in this PR as an example.

Core: https://github.com/triton-inference-server/core/pull/149
Server: https://github.com/triton-inference-server/server/pull/5204