### PR TITLE
Rename kernel library to work with library exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if(${TRITON_ENABLE_GPU})
 
   set(CUDA_LIBRARIES PUBLIC ${CUDA_LIBRARIES})
   cuda_add_library(
-    kernel-library-new
+    kernel_library_new
     src/kernel.cu src/kernel.h
     OPTIONS -arch compute_53
     OPTIONS -code compute_53,sm_53,sm_60,sm_61,sm_62,sm_70,sm_72,sm_75
@@ -189,7 +189,7 @@ if(${TRITON_ENABLE_GPU})
     PUBLIC
       CUDA::cudart
     PRIVATE
-    kernel-library-new
+    kernel_library_new
   )
 endif() # TRITON_ENABLE_GPU
 
@@ -211,7 +211,7 @@ install(
 if(${TRITON_ENABLE_GPU})
   install(
     TARGETS
-      kernel-library-new
+      kernel_library_new
     EXPORT
       triton-backend-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
Looks like cuda preprocessor is not happy with the hyphens in the [define symbols](https://cmake.org/cmake/help/latest/prop_tgt/DEFINE_SYMBOL.html). The issue happens when an external project is trying to use the kernel_library_new. 

### Before

> nvcc ./kernel.cu -c -o kernel-library-new_generated_kernel.cu.o -ccbin /usr/bin/cc -m64 -Dkernel-library-new_EXPORTS -std=c++11 -I/usr/local/cuda-11/include
> <command-line>: warning: ISO C++11 requires whitespace after the macro name
> /usr/local/cuda-11/include/cuda_runtime.h(279): error: expected a ")"
> 
> /usr/local/cuda-11/include/cuda_runtime.h(285): error: identifier "library" is undefined
> 
> /usr/local/cuda-11/include/cuda_runtime.h(285): error: identifier "new_EXPORTS" is undefined
> 
> /usr/local/cuda-11/include/cuda_runtime.h(285): error: too few arguments in function call
> 
> /usr/local/cuda-11/include/cuda_runtime.h(285): error: expected a ")"
> 
> 5 errors detected in the compilation of "./kernel.cu".


### After

> nvcc ./kernel.cu -c -o kernel-library-new_generated_kernel.cu.o -ccbin /usr/bin/cc -m64 -Dkernel_library_new_EXPORTS -std=c++11 -I/usr/local/cuda-11/include
