### PR TITLE
Auto-formatting with upgrade to clang-format-15

### DIFF
--- a/examples/backends/bls/src/bls.cc
+++ b/examples/backends/bls/src/bls.cc
@@ -212,8 +212,8 @@ BLSExecutor::ConstructFinalResponse(
 {
   // Prepare two TRITONSERVER_InferenceResponse* objects for 'addsub_python' and
   // 'addsub_tf' repectively.
-  std::vector<TRITONSERVER_InferenceResponse*> completed_responses = {nullptr,
-                                                                      nullptr};
+  std::vector<TRITONSERVER_InferenceResponse*> completed_responses = {
+      nullptr, nullptr};
 
   const char* output_name;
   TRITONSERVER_DataType output_datatype;

--- a/examples/backends/bls/src/bls.h
+++ b/examples/backends/bls/src/bls.h
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <future>
+
 #include "bls_utils.h"
 #include "triton/backend/backend_common.h"
 #include "triton/core/tritonbackend.h"

--- a/examples/backends/bls/src/bls_utils.h
+++ b/examples/backends/bls/src/bls_utils.h
@@ -26,6 +26,7 @@
 
 #include <future>
 #include <sstream>
+
 #include "triton/backend/backend_common.h"
 #include "triton/core/tritonbackend.h"
 #include "triton/core/tritonserver.h"

--- a/examples/batching_strategies/single_batching/src/single_batching.cc
+++ b/examples/batching_strategies/single_batching/src/single_batching.cc
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>
+
 #include "triton/core/tritonbackend.h"
 
 namespace triton { namespace core { namespace single_batching {

--- a/examples/batching_strategies/volume_batching/src/volume_batching.cc
+++ b/examples/batching_strategies/volume_batching/src/volume_batching.cc
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>
+
 #include "triton/core/tritonbackend.h"
 
 #define TRITONJSON_STATUSTYPE TRITONSERVER_Error*

--- a/examples/model_repos/bls_models/addsub_python/1/model.py
+++ b/examples/model_repos/bls_models/addsub_python/1/model.py
@@ -27,6 +27,7 @@
 import json
 import triton_python_backend_utils as pb_utils
 
+
 # This model calculates the sum and difference of the INPUT0 and INPUT1 and put
 # the results in OUTPUT0 and OUTPUT1 respectively. For more information
 # regarding how this model.py was written, please refer to Python Backend.

--- a/include/triton/backend/backend_common.h
+++ b/include/triton/backend/backend_common.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "triton/common/error.h"
 #include "triton/core/tritonbackend.h"
 

--- a/include/triton/backend/backend_input_collector.h
+++ b/include/triton/backend/backend_input_collector.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "triton/backend/backend_common.h"
 #include "triton/backend/backend_memory.h"
 #include "triton/common/async_work_queue.h"

--- a/include/triton/backend/backend_memory.h
+++ b/include/triton/backend/backend_memory.h
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <vector>
+
 #include "triton/core/tritonbackend.h"
 #include "triton/core/tritonserver.h"
 

--- a/include/triton/backend/backend_model.h
+++ b/include/triton/backend/backend_model.h
@@ -28,6 +28,7 @@
 #include <map>
 #include <set>
 #include <string>
+
 #include "triton/backend/backend_common.h"
 #include "triton/core/tritonbackend.h"
 #include "triton/core/tritonserver.h"

--- a/include/triton/backend/backend_model_instance.h
+++ b/include/triton/backend/backend_model_instance.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <string>
+
 #include "triton/core/tritonbackend.h"
 
 #ifdef TRITON_ENABLE_GPU

--- a/include/triton/backend/backend_output_responder.h
+++ b/include/triton/backend/backend_output_responder.h
@@ -28,6 +28,7 @@
 #include <list>
 #include <string>
 #include <vector>
+
 #include "triton/backend/backend_common.h"
 #include "triton/common/async_work_queue.h"
 #include "triton/core/tritonbackend.h"

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -41,6 +41,7 @@
 #include <unistd.h>
 #endif
 #include <sys/stat.h>
+
 #include <algorithm>
 #include <cerrno>
 #include <fstream>

--- a/src/backend_input_collector.cc
+++ b/src/backend_input_collector.cc
@@ -27,6 +27,7 @@
 #include "triton/backend/backend_input_collector.h"
 
 #include <atomic>
+
 #include "triton/backend/backend_common.h"
 #ifdef TRITON_ENABLE_GPU
 #include "kernel.h"
@@ -69,8 +70,8 @@ BackendInputCollector::InputIterator::GetNextContiguousInput(
   TRITONBACKEND_InputBufferForHostPolicy(
       curr_input_, host_policy_, curr_buffer_idx_,
       reinterpret_cast<const void**>(&input->memory_desc_.buffer_),
-      reinterpret_cast<uint64_t*>(&input->memory_desc_.byte_size_), &input->memory_desc_.memory_type_,
-      &input->memory_desc_.memory_type_id_);
+      reinterpret_cast<uint64_t*>(&input->memory_desc_.byte_size_),
+      &input->memory_desc_.memory_type_, &input->memory_desc_.memory_type_id_);
   ++curr_buffer_idx_;
   input->start_request_idx_ = curr_request_idx_;
   input->end_request_idx_ = curr_request_idx_;
@@ -104,7 +105,8 @@ BackendInputCollector::InputIterator::GetNextContiguousInput(
       int64_t next_memory_type_id;
       TRITONBACKEND_InputBufferForHostPolicy(
           curr_input_, host_policy_, curr_buffer_idx_, &next_buffer,
-          reinterpret_cast<uint64_t*>(&next_buffer_byte_size), &next_memory_type, &next_memory_type_id);
+          reinterpret_cast<uint64_t*>(&next_buffer_byte_size),
+          &next_memory_type, &next_memory_type_id);
       if (((input->memory_desc_.buffer_ + input->memory_desc_.byte_size_) !=
            next_buffer) ||
           (input->memory_desc_.memory_type_ != next_memory_type) ||
@@ -167,10 +169,10 @@ BackendInputCollector::GetInputBufferIfContiguous(
       int64_t src_memory_type_id;
 
       RESPOND_AND_SET_NULL_IF_ERROR(
-          &response,
-          TRITONBACKEND_InputBufferForHostPolicy(
-              input, host_policy_cstr_, idx, &src_buffer, reinterpret_cast<uint64_t*>(&src_byte_size),
-              &src_memory_type, &src_memory_type_id));
+          &response, TRITONBACKEND_InputBufferForHostPolicy(
+                         input, host_policy_cstr_, idx, &src_buffer,
+                         reinterpret_cast<uint64_t*>(&src_byte_size),
+                         &src_memory_type, &src_memory_type_id));
       if (*buffer != nullptr) {
         // If have seen the second buffer while coalescing input is not
         // requested, treat the inputs are not contiguous
@@ -292,12 +294,14 @@ BackendInputCollector::ProcessTensor(
       const int64_t memory_type_id = allowed_type.second;
       switch (allowed_type.first) {
         case TRITONSERVER_MEMORY_GPU:
-          alloc_types = {BackendMemory::AllocationType::GPU_POOL,
-                         BackendMemory::AllocationType::GPU};
+          alloc_types = {
+              BackendMemory::AllocationType::GPU_POOL,
+              BackendMemory::AllocationType::GPU};
           break;
         case TRITONSERVER_MEMORY_CPU_PINNED:
-          alloc_types = {BackendMemory::AllocationType::CPU_PINNED_POOL,
-                         BackendMemory::AllocationType::CPU_PINNED};
+          alloc_types = {
+              BackendMemory::AllocationType::CPU_PINNED_POOL,
+              BackendMemory::AllocationType::CPU_PINNED};
           break;
         case TRITONSERVER_MEMORY_CPU:
           alloc_types = {BackendMemory::AllocationType::CPU};
@@ -844,12 +848,14 @@ BackendInputCollector::ProcessBatchInput(
       const int64_t memory_type_id = allowed_type.second;
       switch (allowed_type.first) {
         case TRITONSERVER_MEMORY_GPU:
-          alloc_types = {BackendMemory::AllocationType::GPU_POOL,
-                         BackendMemory::AllocationType::GPU};
+          alloc_types = {
+              BackendMemory::AllocationType::GPU_POOL,
+              BackendMemory::AllocationType::GPU};
           break;
         case TRITONSERVER_MEMORY_CPU_PINNED:
-          alloc_types = {BackendMemory::AllocationType::CPU_PINNED_POOL,
-                         BackendMemory::AllocationType::CPU_PINNED};
+          alloc_types = {
+              BackendMemory::AllocationType::CPU_PINNED_POOL,
+              BackendMemory::AllocationType::CPU_PINNED};
           break;
         case TRITONSERVER_MEMORY_CPU:
           alloc_types = {BackendMemory::AllocationType::CPU};
@@ -1182,12 +1188,14 @@ BackendInputCollector::LaunchCopyKernel(
   std::vector<BackendMemory::AllocationType> alloc_types;
   switch (tensor_memory_type) {
     case TRITONSERVER_MEMORY_GPU:
-      alloc_types = {BackendMemory::AllocationType::GPU_POOL,
-                     BackendMemory::AllocationType::GPU};
+      alloc_types = {
+          BackendMemory::AllocationType::GPU_POOL,
+          BackendMemory::AllocationType::GPU};
       break;
     case TRITONSERVER_MEMORY_CPU_PINNED:
-      alloc_types = {BackendMemory::AllocationType::CPU_PINNED_POOL,
-                     BackendMemory::AllocationType::CPU_PINNED};
+      alloc_types = {
+          BackendMemory::AllocationType::CPU_PINNED_POOL,
+          BackendMemory::AllocationType::CPU_PINNED};
       break;
     case TRITONSERVER_MEMORY_CPU:
       alloc_types = {BackendMemory::AllocationType::CPU};

--- a/src/backend_memory.cc
+++ b/src/backend_memory.cc
@@ -27,6 +27,7 @@
 #include "triton/backend/backend_memory.h"
 
 #include <map>
+
 #include "triton/backend/backend_common.h"
 
 namespace triton { namespace backend {

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -27,6 +27,7 @@
 #include "triton/backend/backend_model_instance.h"
 
 #include <vector>
+
 #include "triton/backend/backend_common.h"
 #include "triton/backend/backend_model.h"
 

--- a/src/kernel.cu
+++ b/src/kernel.cu
@@ -24,9 +24,9 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "kernel.h"
-
 #include <cuda.h>
+
+#include "kernel.h"
 
 #define THREADBLOCK_SIZE 512
 __launch_bounds__(THREADBLOCK_SIZE) __global__ void TritonGatherKernel(


### PR DESCRIPTION
Due to the [upgrade from clang-format-6.0 to clang-format-15](https://github.com/triton-inference-server/common/pull/94), this PR formats this repository based on the updated `format.py` script. This Clang upgrade was due to the shift to Ubuntu 22.04 base containers, which do not have clang-format-6.0.