### PR TITLE
Add docs on BackendAttributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,31 @@ a successful request. See [Inference Requests and
 Responses](#inference-requests-and-responses) for more information
 about request-response lifecycle.
 
+#### TRITONBACKEND_BackendAttribute
+
+A `TRITONBACKEND_BackendAttribute` allows a backend to set certain attributes which
+are queried by Triton to inform certain feature support, preferred configurations, and
+other types of backend-specific behavior.
+
+When initializing a backend, Triton will query the `TRITONBACKEND_GetBackendAttribute` function
+if implemented by the backend. This function is optional to implement, but is generally used to call
+the related `TRITONBACKEND_BackendAttribute` APIs for setting backend-specific attributes.
+
+Some of the relevant BackendAttribute setter APIs are listed below:
+- `TRITONBACKEND_BackendSetExecutionPolicy`
+- `TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup`
+    - Defines a priority list of instance groups to prefer for this backend if a model config doesn't explicitly define any instance groups.
+- `TRITONBACKEND_BackendAttributeSetParallelModelInstanceLoading`
+    - Defines whether the backend can safely handle concurrent calls to `TRITONBACKEND_ModelInstanceInitialize` or not.
+    - Loading model instances in parallel can improve server startup times for large instance counts.
+    - By default, this attribute is set to false, meaning that parallel instance loading is disabled for all backends unless explicitly enabled.
+    - The following official backends currently support loading model instances in parallel:
+        - Python
+        - ONNXRuntime
+
+The full list of `TRITONBACKEND_BackendAttribute` related APIs are defined in
+[tritonbackend.h](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritonbackend.h).
+
 ### Backend Lifecycles
 
 A backend must carefully manage the lifecycle of the backend itself,

--- a/include/triton/backend/device_memory_tracker.h
+++ b/include/triton/backend/device_memory_tracker.h
@@ -70,10 +70,6 @@ namespace triton { namespace backend {
 ///
 /// Typical usage:
 ///
-/// The backend must implement TRITONBACKEND_GetBackendAttribute which will
-/// call TRITONBACKEND_BackendAttributeSetEnableMemoryTracker with proper
-/// arguments, and must implement TRITONBACKEND_ModelMemoryUsage.
-///
 /// On TRITONBACKEND_Initialize
 ///  - Call DeviceMemoryTracker::Init
 ///


### PR DESCRIPTION
Adds generic docs on BackendAttributes as I didn't find any existing docs other than the API headers.

Just wanted to give a high level overview of attributes and improve searchability, detailed information about them can be found in headers.

Specifically call out the parallel instance loading attribute, and list the currently supported official backends related to ORT PR: https://github.com/triton-inference-server/onnxruntime_backend/pull/208

---

Also noticed this mention of device memory tracking [BackendAttribute here](https://github.com/triton-inference-server/backend/blob/2f3f44eba661af9b4fcd62160eafd9012db32652/include/triton/backend/device_memory_tracker.h#L73C1-L75), but I think it's outdated from initial design. edit: Confirmed with Guan and removed it.