### PR TITLE
Bump min cxx standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,14 @@ option(TRITON_ENABLE_MEMORY_TRACKER "Include device memory tracker in backend ut
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 
-# C++ standard
+# Setting C++ standard
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
+if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
+  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
+else()
+  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -79,7 +85,7 @@ if(${TRITON_ENABLE_GPU})
   find_package(CUDAToolkit REQUIRED)
   find_package(CUDA REQUIRED)
   message(STATUS "Using CUDA ${CUDA_VERSION}")
-  set(CUDA_NVCC_FLAGS -std=c++${TRITON_MIN_CXX_STANDARD})
+  set(CUDA_NVCC_FLAGS -std=c++${BACKEND_CMAKE_CXX_STANDARD})
 
   if(CUDA_VERSION VERSION_GREATER "10.1" OR CUDA_VERSION VERSION_EQUAL "10.1")
     add_definitions(-DTRITON_ENABLE_CUDA_GRAPH=1)
@@ -149,6 +155,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
       "to corresponding value.")
 endif()
 
+target_compile_features(triton-backend-utils PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
 target_compile_options(
   triton-backend-utils
   PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,14 +40,10 @@ option(TRITON_ENABLE_MEMORY_TRACKER "Include device memory tracker in backend ut
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 
+#
 # Setting C++ standard
+#
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
-
-if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
-  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
-else()
-  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
-endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -85,7 +81,7 @@ if(${TRITON_ENABLE_GPU})
   find_package(CUDAToolkit REQUIRED)
   find_package(CUDA REQUIRED)
   message(STATUS "Using CUDA ${CUDA_VERSION}")
-  set(CUDA_NVCC_FLAGS -std=c++${BACKEND_CMAKE_CXX_STANDARD})
+  set(CUDA_NVCC_FLAGS -std=c++${TRITON_MIN_CXX_STANDARD})
 
   if(CUDA_VERSION VERSION_GREATER "10.1" OR CUDA_VERSION VERSION_EQUAL "10.1")
     add_definitions(-DTRITON_ENABLE_CUDA_GRAPH=1)
@@ -155,7 +151,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
       "to corresponding value.")
 endif()
 
-target_compile_features(triton-backend-utils PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
+target_compile_features(triton-backend-utils PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-backend-utils
   PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ option(TRITON_ENABLE_MEMORY_TRACKER "Include device memory tracker in backend ut
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 
+# C++ standard
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -76,7 +79,7 @@ if(${TRITON_ENABLE_GPU})
   find_package(CUDAToolkit REQUIRED)
   find_package(CUDA REQUIRED)
   message(STATUS "Using CUDA ${CUDA_VERSION}")
-  set(CUDA_NVCC_FLAGS -std=c++11)
+  set(CUDA_NVCC_FLAGS -std=c++${TRITON_MIN_CXX_STANDARD})
 
   if(CUDA_VERSION VERSION_GREATER "10.1" OR CUDA_VERSION VERSION_EQUAL "10.1")
     add_definitions(-DTRITON_ENABLE_CUDA_GRAPH=1)
@@ -145,7 +148,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
       "If the target system is not Windows 10, please update _WIN32_WINNT "
       "to corresponding value.")
 endif()
-target_compile_features(triton-backend-utils PRIVATE cxx_std_11)
+
 target_compile_options(
   triton-backend-utils
   PRIVATE

--- a/examples/backends/bls/CMakeLists.txt
+++ b/examples/backends/bls/CMakeLists.txt
@@ -44,6 +44,9 @@ set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 
+# C++ min standard
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -100,7 +103,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-bls-backend PRIVATE cxx_std_11)
+target_compile_features(triton-bls-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-bls-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/backends/bls/CMakeLists.txt
+++ b/examples/backends/bls/CMakeLists.txt
@@ -44,14 +44,10 @@ set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 
+#
 # Setting C++ min standard
+#
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
-
-if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
-  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
-else()
-  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
-endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -109,7 +105,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-bls-backend PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
+target_compile_features(triton-bls-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-bls-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/backends/bls/CMakeLists.txt
+++ b/examples/backends/bls/CMakeLists.txt
@@ -44,8 +44,14 @@ set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 
-# C++ min standard
+# Setting C++ min standard
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
+if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
+  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
+else()
+  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -103,7 +109,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-bls-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
+target_compile_features(triton-bls-backend PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
 target_compile_options(
   triton-bls-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/backends/minimal/CMakeLists.txt
+++ b/examples/backends/minimal/CMakeLists.txt
@@ -44,8 +44,14 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
-# C++ min standard
+# Setting C++ min standard
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
+if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
+  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
+else()
+  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -100,7 +106,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-minimal-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
+target_compile_features(triton-minimal-backend PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
 target_compile_options(
   triton-minimal-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/backends/minimal/CMakeLists.txt
+++ b/examples/backends/minimal/CMakeLists.txt
@@ -44,14 +44,10 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
+#
 # Setting C++ min standard
+#
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
-
-if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
-  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
-else()
-  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
-endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -106,7 +102,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-minimal-backend PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
+target_compile_features(triton-minimal-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-minimal-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/backends/minimal/CMakeLists.txt
+++ b/examples/backends/minimal/CMakeLists.txt
@@ -44,6 +44,9 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
+# C++ min standard
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -97,7 +100,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-minimal-backend PRIVATE cxx_std_11)
+target_compile_features(triton-minimal-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-minimal-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/backends/recommended/CMakeLists.txt
+++ b/examples/backends/recommended/CMakeLists.txt
@@ -44,14 +44,10 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
+#
 # Setting C++ min standard
+#
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
-
-if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
-  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
-else()
-  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
-endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -106,7 +102,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-recommended-backend PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
+target_compile_features(triton-recommended-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-recommended-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/backends/recommended/CMakeLists.txt
+++ b/examples/backends/recommended/CMakeLists.txt
@@ -44,6 +44,9 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
+# C++ min standard
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -97,7 +100,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-recommended-backend PRIVATE cxx_std_11)
+target_compile_features(triton-recommended-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-recommended-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/backends/recommended/CMakeLists.txt
+++ b/examples/backends/recommended/CMakeLists.txt
@@ -44,8 +44,14 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
-# C++ min standard
+# Setting C++ min standard
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
+if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
+  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
+else()
+  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -100,7 +106,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-recommended-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
+target_compile_features(triton-recommended-backend PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
 target_compile_options(
   triton-recommended-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/batching_strategies/single_batching/CMakeLists.txt
+++ b/examples/batching_strategies/single_batching/CMakeLists.txt
@@ -32,14 +32,10 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
+#
 # Setting C++ min standard
+#
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
-
-if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
-  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
-else()
-  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
-endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -90,7 +86,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-single-batching PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
+target_compile_features(triton-single-batching PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-single-batching PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/batching_strategies/single_batching/CMakeLists.txt
+++ b/examples/batching_strategies/single_batching/CMakeLists.txt
@@ -32,6 +32,9 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
+# C++ min standard
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -81,7 +84,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-single-batching PRIVATE cxx_std_11)
+target_compile_features(triton-single-batching PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-single-batching PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/batching_strategies/single_batching/CMakeLists.txt
+++ b/examples/batching_strategies/single_batching/CMakeLists.txt
@@ -32,8 +32,14 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
-# C++ min standard
+# Setting C++ min standard
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
+if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
+  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
+else()
+  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -84,7 +90,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-single-batching PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
+target_compile_features(triton-single-batching PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
 target_compile_options(
   triton-single-batching PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/batching_strategies/volume_batching/CMakeLists.txt
+++ b/examples/batching_strategies/volume_batching/CMakeLists.txt
@@ -32,14 +32,10 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
+#
 # Setting C++ min standard
+#
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
-
-if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
-  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
-else()
-  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
-endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -90,7 +86,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-volume-batching PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
+target_compile_features(triton-volume-batching PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-volume-batching PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/batching_strategies/volume_batching/CMakeLists.txt
+++ b/examples/batching_strategies/volume_batching/CMakeLists.txt
@@ -32,8 +32,14 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
-# C++ min standard
+# Setting C++ min standard
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
+if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
+  set(BACKEND_CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
+else()
+  set(BACKEND_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -84,7 +90,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-volume-batching PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
+target_compile_features(triton-volume-batching PRIVATE cxx_std_${BACKEND_CMAKE_CXX_STANDARD})
 target_compile_options(
   triton-volume-batching PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/examples/batching_strategies/volume_batching/CMakeLists.txt
+++ b/examples/batching_strategies/volume_batching/CMakeLists.txt
@@ -32,6 +32,9 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
+# C++ min standard
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -81,7 +84,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-volume-batching PRIVATE cxx_std_11)
+target_compile_features(triton-volume-batching PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-volume-batching PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:


### PR DESCRIPTION
This PR is one of the series PRs to update Triton to C++17 standard.

Introduced logic: either set `TRITON_MIN_CXX_STANDARD` to 17 or use cached value. Later,`TRITON_MIN_CXX_STANDARD`  is used to set min required standard through `target_compile_features`.