### PR TITLE
BackendMemory::Create must release all errors

### DIFF
--- a/src/backend_memory.cc
+++ b/src/backend_memory.cc
@@ -143,6 +143,12 @@ BackendMemory::Create(
     return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_UNAVAILABLE, msg.c_str());
   }
 
+  // If it succeeded we might have to clean up errors associated with
+  // attempts that failed
+  for (const auto& pr : errors) {
+    TRITONSERVER_ErrorDelete(pr.second);
+  }
+
   return nullptr;  // success
 }
 


### PR DESCRIPTION
This PR changes `BackendMemory::Create` to make it release errors even if the allocation request succeeded. `BackendMemory::Create` allows callers to try different allocation types. However, it was not properly releasing the error associated with attempts that failed prior to the one that succeeded. 

Valgrind generates the following error while debugging the Triton Server:
```
==76== 182,619 (70,920 direct, 111,699 indirect) bytes in 1,773 blocks are definitely lost in loss record 1,321 of 1,321
==76==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==76==    by 0x5319270: TRITONSERVER_ErrorNew (in /opt/tritonserver/lib/libtritonserver.so)
==76==    by 0x5184A53: TRITONBACKEND_MemoryManagerAllocate (in /opt/tritonserver/lib/libtritonserver.so)
==76==    by 0x15F16833: triton::backend::BackendMemory::Create(TRITONBACKEND_MemoryManager*, triton::backend::BackendMemory::AllocationType, long, unsigned long, triton::backend::BackendMemory**) (in /opt/tritonserver/backends/onnxruntime/libtriton_onnxruntime.so)
==76==    by 0x15F17B5A: triton::backend::BackendMemory::Create(TRITONBACKEND_MemoryManager*, std::vector<triton::backend::BackendMemory::AllocationType, std::allocator<triton::backend::BackendMemory::AllocationType> > const&, long, unsigned long, triton::backend::BackendMemory**) (in /opt/tritonserver/backends/onnxruntime/libtriton_onnxruntime.so)
==76==    by 0x15EC4945: triton::backend::onnxruntime::ModelInstanceState::SetStringInputTensor(TRITONBACKEND_Request**, unsigned int, std::vector<TRITONBACKEND_Response*, std::allocator<TRITONBACKEND_Response*> >*, char const*, std::vector<char const*, std::allocator<char const*> >*, bool*) (in /opt/tritonserver/backends/onnxruntime/libtriton_onnxruntime.so)
==76==    by 0x15EC748A: triton::backend::onnxruntime::ModelInstanceState::SetInputTensors(unsigned long, TRITONBACKEND_Request**, unsigned int, std::vector<TRITONBACKEND_Response*, std::allocator<TRITONBACKEND_Response*> >*, triton::backend::BackendInputCollector*, std::vector<char const*, std::allocator<char const*> >*, bool*) (in /opt/tritonserver/backends/onnxruntime/libtriton_onnxruntime.so)
==76==    by 0x15ECDF6E: triton::backend::onnxruntime::ModelInstanceState::ProcessRequests(TRITONBACKEND_Request**, unsigned int) (in /opt/tritonserver/backends/onnxruntime/libtriton_onnxruntime.so)
==76==    by 0x15ED1B83: TRITONBACKEND_ModelInstanceExecute (in /opt/tritonserver/backends/onnxruntime/libtriton_onnxruntime.so)
==76==    by 0x51A3F13: triton::core::TritonModelInstance::Execute(std::vector<TRITONBACKEND_Request*, std::allocator<TRITONBACKEND_Request*> >&) (in /opt/tritonserver/lib/libtritonserver.so)
==76==    by 0x51A427A: triton::core::TritonModelInstance::Schedule(std::vector<std::unique_ptr<triton::core::InferenceRequest, std::default_delete<triton::core::InferenceRequest> >, std::allocator<std::unique_ptr<triton::core::InferenceRequest, std::default_delete<triton::core::InferenceRequest> > > >&&) (in /opt/tritonserver/lib/libtritonserver.so)
==76==    by 0x52B505C: triton::core::Payload::Execute(bool*) (in /opt/tritonserver/lib/libtritonserver.so)
==76==    by 0x51A86A3: triton::core::TritonModelInstance::TritonBackendThread::BackendThread() (in /opt/tritonserver/lib/libtritonserver.so)
==76==    by 0x6940252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
==76==    by 0x6B24AC2: start_thread (pthread_create.c:442)
==76==    by 0x6BB5A03: clone (clone.S:100)
```
