### PR TITLE
chore: Use log level ERROR when logging backend errors with LOG_IF_ERROR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option(TRITON_ENABLE_STATS "Include statistics collections in backend utilities"
 # Default OFF unless backend explicitly request to use provided implementation
 option(TRITON_ENABLE_MEMORY_TRACKER "Include device memory tracker in backend utilities" OFF)
 
+set(TRITON_REPO_ORGANIZATION "https://github.com/triton-inference-server" CACHE STRING "Git repository to pull from")
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2020-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/include/triton/backend/backend_common.h
+++ b/include/triton/backend/backend_common.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/include/triton/backend/backend_common.h
+++ b/include/triton/backend/backend_common.h
@@ -63,7 +63,7 @@ namespace triton { namespace backend {
     TRITONSERVER_Error* lie_err__ = (X);                                       \
     if (lie_err__ != nullptr) {                                                \
       IGNORE_ERROR(TRITONSERVER_LogMessage(                                    \
-          TRITONSERVER_LOG_INFO, __FILE__, __LINE__,                           \
+          TRITONSERVER_LOG_ERROR, __FILE__, __LINE__,                          \
           (std::string(MSG) + ": " + TRITONSERVER_ErrorCodeString(lie_err__) + \
            " - " + TRITONSERVER_ErrorMessage(lie_err__))                       \
               .c_str()));                                                      \


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/core/pull/367

1. Use log level ERROR for LOG_IF_ERROR

Before, `LOG_IF_ERROR` would prefix the line with `I` for level `INFO`:
```
E0605 22:07:23.729999 1135 identity.cc:1175] request 0: failed to get copy buffer, error response sent
I0605 22:07:23.730046 1135 identity.cc:1189] failed setting string parameter: Invalid argument - response was nullptr
I0605 22:07:23.730084 1135 identity.cc:1193] failed setting integer parameter: Invalid argument - response was nullptr
I0605 22:07:23.730123 1135 identity.cc:1196] failed setting boolean parameter: Invalid argument - response was nullptr
I0605 22:07:23.730162 1135 identity.cc:1199] failed setting double parameter: Invalid argument - response was nullptr
```
After, it uses `E` for `ERROR`:
```
E0605 22:07:23.729999 1135 identity.cc:1175] request 0: failed to get copy buffer, error response sent
E0605 22:07:23.730046 1135 identity.cc:1189] failed setting string parameter: Invalid argument - response was nullptr
E0605 22:07:23.730084 1135 identity.cc:1193] failed setting integer parameter: Invalid argument - response was nullptr
E0605 22:07:23.730123 1135 identity.cc:1196] failed setting boolean parameter: Invalid argument - response was nullptr
E0605 22:07:23.730162 1135 identity.cc:1199] failed setting double parameter: Invalid argument - response was nullptr
```

---

2. Add default `TRITON_REPO_ORGANIZATION` for building locally.