### PR TITLE
refactor: Prevent overflow in backend APIs

### DIFF
--- a/include/triton/backend/backend_common.h
+++ b/include/triton/backend/backend_common.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -320,23 +320,58 @@ std::string ShapeToString(const std::vector<int64_t>& shape);
 ///
 /// \param dims The shape dimensions.
 /// \param dims_count The number of dimensions.
-/// \return The number of elements.
+/// \return The number of elements,
+/// -1 if unable to determine the number,
+/// -2 if the shape contains an invalid dim,
+/// or -3 if the number is too large to represent as an int64_t.
 int64_t GetElementCount(const int64_t* dims, const size_t dims_count);
 
 /// Return the number of elements of a shape.
 ///
 /// \param shape The shape as a vector of dimensions.
-/// \return The number of elements.
+/// \return The number of elements,
+/// -1 if unable to determine the number,
+/// -2 if the shape contains an invalid dim,
+/// or -3 if the number is too large to represent as an int64_t.
 int64_t GetElementCount(const std::vector<int64_t>& shape);
+
+/// Return the number of elements of a shape with error checking.
+///
+/// \param dims The shape dimensions.
+/// \param dims_count The number of dimensions.
+/// \param cnt Returns the number of elements.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_Error* GetElementCount(
+    const int64_t* dims, const size_t dims_count, int64_t* cnt);
+
+/// Return the number of elements of a shape with error checking.
+///
+/// \param shape The shape as a vector of dimensions.
+/// \param cnt Returns the number of elements.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_Error* GetElementCount(
+    const std::vector<int64_t>& shape, int64_t* cnt);
 
 /// Get the size, in bytes, of a tensor based on datatype and
 /// shape.
 /// \param dtype The data-type.
 /// \param dims The shape.
-/// \return The size, in bytes, of the corresponding tensor, or -1 if
-/// unable to determine the size.
+/// \return The size, in bytes, of the corresponding tensor,
+/// -1 if unable to determine the size,
+/// -2 if the shape contains an invalid dim,
+/// or -3 if the size is too large to represent as an int64_t.
 int64_t GetByteSize(
     const TRITONSERVER_DataType& dtype, const std::vector<int64_t>& dims);
+
+/// Get the size, in bytes, of a tensor based on datatype and
+/// shape with error checking.
+/// \param dtype The data-type.
+/// \param dims The shape.
+/// \param size Returns the size, in bytes, of the corresponding tensor.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_Error* GetByteSize(
+    const TRITONSERVER_DataType& dtype, const std::vector<int64_t>& dims,
+    int64_t* size);
 
 /// Get an input tensor's contents into a buffer. This overload expects
 /// both 'buffer' and buffers of the input to be in CPU.

--- a/include/triton/backend/backend_common.h
+++ b/include/triton/backend/backend_common.h
@@ -316,6 +316,7 @@ std::string ShapeToString(const int64_t* dims, const size_t dims_count);
 /// \return The string representation.
 std::string ShapeToString(const std::vector<int64_t>& shape);
 
+/// Deprecated. Use TRITONSERVER_Error* GetElementCount instead.
 /// Return the number of elements of a shape.
 ///
 /// \param dims The shape dimensions.
@@ -326,6 +327,7 @@ std::string ShapeToString(const std::vector<int64_t>& shape);
 /// or -3 if the number is too large to represent as an int64_t.
 int64_t GetElementCount(const int64_t* dims, const size_t dims_count);
 
+/// Deprecated. Use TRITONSERVER_Error* GetElementCount instead.
 /// Return the number of elements of a shape.
 ///
 /// \param shape The shape as a vector of dimensions.
@@ -352,6 +354,7 @@ TRITONSERVER_Error* GetElementCount(
 TRITONSERVER_Error* GetElementCount(
     const std::vector<int64_t>& shape, int64_t* cnt);
 
+/// Deprecated. Use TRITONSERVER_Error* GetByteSize instead.
 /// Get the size, in bytes, of a tensor based on datatype and
 /// shape.
 /// \param dtype The data-type.

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -166,8 +166,10 @@ GetElementCount(const int64_t* dims, const size_t dims_count)
   for (size_t i = 0; i < dims_count; i++) {
     if (dims[i] == WILDCARD_DIM) {
       return -1;
-    } else if (dims[i] < 0) {
+    } else if (dims[i] < 0) {  // invalid dim
       return -2;
+    } else if (dims[i] == 0) {
+      return 0;
     }
 
     if (first) {
@@ -237,7 +239,7 @@ GetByteSize(
   }
 
   int64_t cnt = GetElementCount(dims);
-  if (cnt < 0) {
+  if (cnt <= 0) {
     return cnt;
   }
 

--- a/src/backend_common.cc
+++ b/src/backend_common.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -166,12 +166,18 @@ GetElementCount(const int64_t* dims, const size_t dims_count)
   for (size_t i = 0; i < dims_count; i++) {
     if (dims[i] == WILDCARD_DIM) {
       return -1;
+    } else if (dims[i] < 0) {
+      return -2;
     }
 
     if (first) {
       cnt = dims[i];
       first = false;
     } else {
+      // Check for overflow before multiplication
+      if (cnt > INT64_MAX / dims[i]) {
+        return -3;
+      }
       cnt *= dims[i];
     }
   }
@@ -185,6 +191,42 @@ GetElementCount(const std::vector<int64_t>& shape)
   return GetElementCount(shape.data(), shape.size());
 }
 
+TRITONSERVER_Error*
+GetElementCount(const int64_t* dims, const size_t dims_count, int64_t* cnt)
+{
+  *cnt = GetElementCount(dims, dims_count);
+  if (*cnt == -2) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        (std::string("shape") + ShapeToString(dims, dims_count) +
+         " contains an invalid dim.")
+            .c_str());
+  } else if (*cnt == -3) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "unexpected integer overflow while calculating element count.");
+  }
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error*
+GetElementCount(const std::vector<int64_t>& shape, int64_t* cnt)
+{
+  *cnt = GetElementCount(shape.data(), shape.size());
+  if (*cnt == -2) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        (std::string("shape") + ShapeToString(shape) +
+         " contains an invalid dim.")
+            .c_str());
+  } else if (*cnt == -3) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "unexpected integer overflow while calculating element count.");
+  }
+  return nullptr;  // success
+}
+
 int64_t
 GetByteSize(
     const TRITONSERVER_DataType& dtype, const std::vector<int64_t>& dims)
@@ -195,11 +237,34 @@ GetByteSize(
   }
 
   int64_t cnt = GetElementCount(dims);
-  if (cnt == -1) {
-    return -1;
+  if (cnt < 0) {
+    return cnt;
   }
 
+  if ((cnt > INT64_MAX / dt_size)) {
+    return -3;
+  }
   return cnt * dt_size;
+}
+
+TRITONSERVER_Error*
+GetByteSize(
+    const TRITONSERVER_DataType& dtype, const std::vector<int64_t>& dims,
+    int64_t* size)
+{
+  *size = GetByteSize(dtype, dims);
+  if (*size == -2) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        (std::string("shape") + ShapeToString(dims) +
+         " contains an invalid dim.")
+            .c_str());
+  } else if (*size == -3) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "unexpected integer overflow while calculating byte size.");
+  }
+  return nullptr;  // success
 }
 
 TRITONSERVER_Error*

--- a/src/backend_output_responder.cc
+++ b/src/backend_output_responder.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -109,7 +109,9 @@ BackendOutputResponder::ProcessTensor(
       batch_size_offset += shape[0];
     }
 
-    const size_t tensor_byte_size = GetByteSize(datatype, batchn_shape);
+    int64_t tensor_byte_size = 0;
+    RESPOND_AND_SET_NULL_IF_ERROR(
+        &response, GetByteSize(datatype, batchn_shape, &tensor_byte_size));
 
     TRITONBACKEND_Output* response_output;
     if (response != nullptr) {
@@ -218,7 +220,9 @@ BackendOutputResponder::ProcessStateTensor(
       batch_size_offset += shape[0];
     }
 
-    const size_t tensor_byte_size = GetByteSize(datatype, batchn_shape);
+    int64_t tensor_byte_size = 0;
+    RESPOND_AND_SET_NULL_IF_ERROR(
+        &response, GetByteSize(datatype, batchn_shape, &tensor_byte_size));
 
     TRITONBACKEND_State* output_state;
     if (response != nullptr) {
@@ -554,8 +558,10 @@ BackendOutputResponder::ProcessBatchOutput(
           }
         }
 
-        const size_t tensor_byte_size =
-            GetByteSize(datatype, output_batchn_shape);
+        int64_t tensor_byte_size = 0;
+        RESPOND_AND_SET_NULL_IF_ERROR(
+            &response,
+            GetByteSize(datatype, output_batchn_shape, &tensor_byte_size));
 
         TRITONBACKEND_Output* response_output;
         if (response != nullptr) {


### PR DESCRIPTION
Add additional checks in function GetElementCount and GetByteSize.
Return -2 if invalid dim.
Return -3 if overflow.