### PR TITLE
build: add Conan 2 + CMakePresets build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,21 +58,26 @@ endif()
 #
 # Dependencies
 #
+option(TRITON_SKIP_THIRD_PARTY_FETCH
+  "Skip FetchContent for common/core deps (provided by parent build or Conan)" OFF)
+
 include(FetchContent)
 
-FetchContent_Declare(
-  repo-common
-  GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/common.git
-  GIT_TAG ${TRITON_COMMON_REPO_TAG}
-  GIT_SHALLOW ON
-)
-FetchContent_Declare(
-  repo-core
-  GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/core.git
-  GIT_TAG ${TRITON_CORE_REPO_TAG}
-  GIT_SHALLOW ON
-)
-FetchContent_MakeAvailable(repo-common repo-core)
+if(NOT TRITON_SKIP_THIRD_PARTY_FETCH)
+  FetchContent_Declare(
+    repo-common
+    GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/common.git
+    GIT_TAG ${TRITON_COMMON_REPO_TAG}
+    GIT_SHALLOW ON
+  )
+  FetchContent_Declare(
+    repo-core
+    GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/core.git
+    GIT_TAG ${TRITON_CORE_REPO_TAG}
+    GIT_SHALLOW ON
+  )
+  FetchContent_MakeAvailable(repo-common repo-core)
+endif()
 
 #
 # CUDA

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,4 @@
+{
+  "version": 6,
+  "include": ["cmake/CMakePresets.json"]
+}

--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -1,0 +1,47 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": { "major": 3, "minor": 31, "patch": 8 },
+  "$comment": "Standalone build presets for triton-backend. For integrated server builds use server/cmake/CMakePresets.json — it includes backend via add_subdirectory and its variables take precedence.",
+  "configurePresets": [
+    {
+      "name": "conan-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "toolchainFile": "${sourceDir}/build/${presetName}/conan/conan_toolchain.cmake",
+      "cacheVariables": { "CMAKE_EXPORT_COMPILE_COMMANDS": "ON" }
+    },
+    {
+      "name": "release",
+      "inherits": "conan-base",
+      "displayName": "Release (GPU)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "TRITON_ENABLE_GPU": "ON"
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": "conan-base",
+      "displayName": "Debug (GPU)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "TRITON_ENABLE_GPU": "ON"
+      }
+    },
+    {
+      "name": "cpu-only",
+      "inherits": "conan-base",
+      "displayName": "Release CPU-only",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "TRITON_ENABLE_GPU": "OFF"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "release",  "configurePreset": "release" },
+    { "name": "debug",    "configurePreset": "debug" },
+    { "name": "cpu-only", "configurePreset": "cpu-only" }
+  ]
+}

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,32 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, cmake_layout
+from conan.errors import ConanInvalidConfiguration
+
+
+class TritonBackendConan(ConanFile):
+    name = "triton-backend"
+    version = "2.68.0"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "enable_gpu": [True, False],
+    }
+    default_options = {
+        "enable_gpu": True,
+    }
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("triton-backend only supports Linux")
+
+    def requirements(self):
+        self.requires("rapidjson/cci.20230929")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["TRITON_ENABLE_GPU"]             = self.options.enable_gpu
+        tc.variables["TRITON_SKIP_THIRD_PARTY_FETCH"] = True
+        tc.generate()
+        CMakeDeps(self).generate()

--- a/profiles/linux-gcc13-debug
+++ b/profiles/linux-gcc13-debug
@@ -1,0 +1,13 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.libcxx=libstdc++11
+compiler.cppstd=17
+build_type=Debug
+
+[buildenv]
+CC=/usr/bin/gcc-13
+CXX=/usr/bin/g++-13
+PATH=+/home/user/.venv/bin

--- a/profiles/linux-gcc13-release
+++ b/profiles/linux-gcc13-release
@@ -1,0 +1,13 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.libcxx=libstdc++11
+compiler.cppstd=17
+build_type=Release
+
+[buildenv]
+CC=/usr/bin/gcc-13
+CXX=/usr/bin/g++-13
+PATH=+/home/user/.venv/bin


### PR DESCRIPTION
<sup>
Resolves: TRI-122<br/>
triton-inference-server/common#154<br/>
triton-inference-server/core#490<br/>
triton-inference-server/server#8734<br/>
triton-inference-server/third_party#74
</sup>

## Description

Introduces Conan 2 package manager and CMakePresets-based build system for dependency management in the backend repository, as part of the broader Triton CMake/Conan migration (TRI-122).

## Changes

- build: add Conan 2 + CMakePresets build system

## Affected Files

- CMakeLists.txt
- CMakePresets.json
- cmake/CMakePresets.json
- conanfile.py
- profiles/linux-gcc13-debug
- profiles/linux-gcc13-release