### PR TITLE
ci: enable secret-scan-trufflehog pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 repos:
+- repo: https://github.com/NVIDIA/security-workflows
+  rev: v0.3.0
+  hooks:
+  - id: secret-scan-trufflehog
 - repo: https://github.com/PyCQA/isort
   rev: 5.12.0
   hooks:


### PR DESCRIPTION
## Description

Enables the NVIDIA `secret-scan-trufflehog` pre-commit hook, pinned to `v0.3.0`,
as the first entry under `repos:` so scanning runs before any formatter rewrites
the working tree.

This adopts the centrally maintained hook published by `NVIDIA/security-workflows`
rather than a hand-rolled TruffleHog invocation, so the scanner version and its
per-platform checksums are bumped in one reviewed place instead of 27.

`v0.3.0` is pinned deliberately. It installs the scanner inside pre-commit's own
Python environment — removing the shell installer, so Windows works without Git
Bash — and it adds `--exclude-detectors=lob`. That exclusion matters here: a Lob
API key is `test_` followed by 35 characters, so the detector matches ordinary
pytest function names such as `test_gpu_conf_compute_attestation_report`, and
Lob's verifier reports them as *verified* — the one result class this hook fails
on.

Behaviour: scans only the files pre-commit supplies (staged files at commit time,
the push range at push time), reports verified secrets only, and fails closed on
a finding.

Deliberately **out of scope**:

- No `ci: skip:` block. That is prescribed for the hosted pre-commit.ci sandbox,
  which has no network access. No Triton repo uses pre-commit.ci — CI runs
  pre-commit from `.github/workflows/pre-commit.yml` — so it would be dead config.
- No `default_install_hook_types` change. Activation is a developer action;
  changing that key would alter install behaviour for *every* hook in the repo,
  not just this one. Tracked separately.

## Changes

- Add `NVIDIA/security-workflows` `secret-scan-trufflehog` @ `v0.3.0` as the
  first entry under `repos:`.

## Affected Files

- `.pre-commit-config.yaml`

## Test plan

- `pre-commit validate-config` — passes.
- `pre-commit run secret-scan-trufflehog --all-files` — passes, with **zero**
  pre-existing verified secrets, so CI does not break on merge.
- TruffleHog **3.95.9** confirmed installed into pre-commit's Python environment
  and executed, so the hook is functional rather than a silent no-op.
- Blast radius is bounded: `.github/workflows/pre-commit.yml` runs
  `pre-commit run --files` against PR-modified paths only, never `--all-files`.

## Caveats

Editing the config alone scans nothing. Each contributor must run once per clone:

```
pre-commit install --hook-type pre-commit
pre-commit install --hook-type pre-push
```

Without the second, the `pre-push` stage stays dormant.

## Related PRs

- triton-inference-server/server#8929
- triton-inference-server/core#521
- triton-inference-server/common#163
- triton-inference-server/client#916
- triton-inference-server/python_backend#452
- triton-inference-server/pytorch_backend#206
- triton-inference-server/onnxruntime_backend#356
- triton-inference-server/openvino_backend#120
- triton-inference-server/tensorrt_backend#126
- triton-inference-server/tensorrtllm_backend#862
- triton-inference-server/vllm_backend#136
- triton-inference-server/fil_backend#459
- triton-inference-server/identity_backend#37
- triton-inference-server/repeat_backend#20
- triton-inference-server/square_backend#23
- triton-inference-server/model_analyzer#1033
- triton-inference-server/perf_analyzer#468
- triton-inference-server/triton_cli#128
- triton-inference-server/local_cache#17
- triton-inference-server/redis_cache#25
- triton-inference-server/checksum_repository_agent#15
- triton-inference-server/developer_tools#62
- triton-inference-server/third_party#81
- triton-inference-server/tutorials#166

Also part of this rollout, on internal GitLab: `dl/dgx/tritonserver!1853` and `dl/dgx/tritonmodelanalyzer!181`.

## Related Issues

- Resolves: TRI-1701
